### PR TITLE
Consul multi node and HA 

### DIFF
--- a/Setup/docker-compose.yml
+++ b/Setup/docker-compose.yml
@@ -232,7 +232,7 @@ services:
           - shield
         environment:
           - SSLEXCLUSION=true
-#        env_file: proxy-server.env
+        env_file: proxy-server.env
         deploy:
           replicas: 2
           restart_policy:

--- a/Setup/docker-compose_dev.yml
+++ b/Setup/docker-compose_dev.yml
@@ -86,7 +86,7 @@ services:
       endpoint_mode: dnsrr
       placement:
         constraints:
-            - node.labels.management==yes
+            - node.labels.consul-server==yes
       update_config:
           parallelism: 1
           failure_action: rollback
@@ -98,11 +98,12 @@ services:
           cpus: "1"
     environment:
         - "CONSUL_BIND_INTERFACE=eth0"
-        - "NUMBER_OF_EXPECTED=1"
+        - "NUMBER_OF_EXPECTED=3"
     logging:
       driver: syslog
       options:
         syslog-address: udp://${SYS_LOG_HOST}:5014
+
   consul:
       image: securebrowsing/shield-configuration:multi
       networks:
@@ -124,10 +125,10 @@ services:
       environment:
           - "CONSUL_BIND_INTERFACE=eth2"
           - "RUN_AGENT=yes"
-    logging:
-      driver: syslog
-      options:
-        syslog-address: udp://${SYS_LOG_HOST}:5014
+      logging:
+        driver: syslog
+        options:
+          syslog-address: udp://${SYS_LOG_HOST}:5014
 
 ###################################################################### Shield services part ##################################################################
   shield-admin:
@@ -228,7 +229,7 @@ services:
             syslog-address: udp://${SYS_LOG_HOST}:5014
 
   shield-browser:
-        image: securebrowsing/shield-cef:latest
+        image: securebrowsing/shield-cef:171016-13.17-294
         user: user
         ulimits:
             nice: -20
@@ -447,6 +448,7 @@ networks:
       driver: default
       config:
         - subnet: 192.168.0.0/16
+
 secrets:
    shield-system-id:
        external: true

--- a/Setup/docker-compose_dev.yml
+++ b/Setup/docker-compose_dev.yml
@@ -77,7 +77,7 @@ services:
          - elastic:/var/lib
 
   consul-server:
-    image: securebrowsing/shield-configuration:multi
+    image: securebrowsing/shield-configuration:latest
     networks:
          - shield
     deploy:
@@ -105,7 +105,7 @@ services:
         syslog-address: udp://${SYS_LOG_HOST}:5014
 
   consul:
-      image: securebrowsing/shield-configuration:multi
+      image: securebrowsing/shield-configuration:latest
       networks:
            - shield
       ports:

--- a/Setup/docker-compose_dev.yml
+++ b/Setup/docker-compose_dev.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: "3.3"
 
 # Ericom Shield Stack Description
 # YML file for Dev
@@ -75,16 +75,15 @@ services:
             cpus: "1"
       volumes:
          - elastic:/var/lib
-    
-  consul:
-    image: securebrowsing/shield-configuration:latest
+
+  consul-server:
+    image: securebrowsing/shield-configuration:multi
     networks:
          - shield
-    ports:
-        - "8500:8500"
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 3
+      endpoint_mode: dnsrr
       placement:
         constraints:
             - node.labels.management==yes
@@ -98,8 +97,33 @@ services:
           memory: 1GB
           cpus: "1"
     environment:
-        - "CONSUL_BIND_INTERFACE=eth2"
+        - "CONSUL_BIND_INTERFACE=eth0"
         - "NUMBER_OF_EXPECTED=1"
+    logging:
+      driver: syslog
+      options:
+        syslog-address: udp://${SYS_LOG_HOST}:5014
+  consul:
+      image: securebrowsing/shield-configuration:multi
+      networks:
+           - shield
+      ports:
+          - "8500:8500"
+      deploy:
+        mode: replicated
+        replicas: 1
+        update_config:
+            parallelism: 1
+            failure_action: rollback
+        restart_policy:
+            condition: any
+        resources:
+          limits:
+            memory: 1GB
+            cpus: "1"
+      environment:
+          - "CONSUL_BIND_INTERFACE=eth2"
+          - "RUN_AGENT=yes"
     logging:
       driver: syslog
       options:
@@ -321,8 +345,8 @@ services:
       logging:
           driver: syslog
           options:
-            syslog-address: udp://${SYS_LOG_HOST}:5014          
-    
+            syslog-address: udp://${SYS_LOG_HOST}:5014
+
   web-service:
         image: securebrowsing/shield-web-service:latest
         ports:

--- a/Setup/docker-compose_dev.yml
+++ b/Setup/docker-compose_dev.yml
@@ -77,7 +77,7 @@ services:
          - elastic:/var/lib
 
   consul-server:
-    image: securebrowsing/shield-configuration:latest
+    image: securebrowsing/shield-configuration:multi
     networks:
          - shield
     deploy:
@@ -86,7 +86,7 @@ services:
       endpoint_mode: dnsrr
       placement:
         constraints:
-            - node.labels.consul-server==yes
+            - node.labels.management==yes
       update_config:
           parallelism: 1
           failure_action: rollback
@@ -105,7 +105,7 @@ services:
         syslog-address: udp://${SYS_LOG_HOST}:5014
 
   consul:
-      image: securebrowsing/shield-configuration:latest
+      image: securebrowsing/shield-configuration:multi
       networks:
            - shield
       ports:


### PR DESCRIPTION
Now we have two parts of consul:

1. Server (X/2 != 0 nodes) this part closed into shield network 
2. Agent run on one of nodes.

All containers speak with agent and not with servers. Right now servers haven't client connection and can answer only to agents.

Single failure when one of nodes is failed (machine or swarm node) then system continues working and losted container will be created on another node.

If more from half of nodes is failed exists chanse to service totally failure, according to consul bag: https://github.com/hashicorp/consul/issues/3361

Please review changes on docker-compose_dev.yml file  

Linked to issue https://github.com/EricomSoftwareLtd/SB/issues/92