### PR TITLE
Dev 246

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+## [Dev:Build_247] - 2018-1-1
+- "no_votiro_payment" license flag should be "false" by default and it's meaning is: "has Votiro license" #1747
+- Admin - Dashboard - fields in green area #1740 #1555
+- Admin: when adding workers, the status remain Not Available, collector can't communicate with consul #1729
+- Fix the tool tip for Standby Remote Browser Sessions #1726
+- Dashboard - the display can misleads in case you have nodes without label browser #1724
+
 ## [Dev:Build_246] - 2017-12-31
 - Fixed https issue with chrome
 

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,17 +1,17 @@
-#Build Dev:Build_246 on 31/12/17
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_246
+#Build Dev:Build_247 on 1/1/18
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_247
 shield-configuration:latest shield-configuration:171224-09.11-846
-shield-admin:latest shield-admin:171228-19.45-922
+shield-admin:latest shield-admin:180101-12.31-940
 shield-portainer:latest shield-portainer:171217-11.30
 proxy-server:latest proxy-server:171219-17.25-837  
 icap-server:latest icap-server:171224-15.12-848
-shield-cef:latest shield-cef:171226-08.23-877
-broker-server:latest broker-server:171228-19.45-922
-shield-collector:latest shield-collector:171228-13.01-915
+shield-cef:latest shield-cef:180101-09.50-934
+broker-server:latest broker-server:180101-12.31-940
+shield-collector:latest shield-collector:180101-11.35-938
 shield-elk:latest shield-elk:171218-08.56-824
 extproxy:latest extproxy:171225-16.59-866
-shield-cdr-dispatcher:latest shield-cdr-dispatcher:171217-19.31-813
-shield-cdr-controller:latest shield-cdr-controller:171217-19.31-813
+shield-cdr-dispatcher:latest shield-cdr-dispatcher:180101-09.50-934
+shield-cdr-controller:latest shield-cdr-controller:180101-09.50-934
 shield-web-service:latest shield-web-service:171217-19.18-812
 shield-maintenance:latest shield-maintenance:171015-11.48-270
 shield-authproxy:latest shield-authproxy:171228-12.02-913


### PR DESCRIPTION
## [Dev:Build_247] - 2018-1-1
- "no_votiro_payment" license flag should be "false" by default and
it's meaning is: "has Votiro license" #1747
- Admin - Dashboard - fields in green area #1740 #1555
- Admin: when adding workers, the status remain Not Available,
collector can't communicate with consul #1729
- Fix the tool tip for Standby Remote Browser Sessions #1726
- Dashboard - the display can misleads in case you have nodes without
label browser #1724