### PR TITLE
Minor fixes until we have a dev build to replace this one

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Staging:18.01-Build_249.7] - 2018-1-21
+- Ignore upstream CA errors by default 
+- Cookies are off by default 
+
 ## [Dev:Build_264] - 2018-1-21
 - (*) Rework on Cookies support , fix page load getting stuck #1878
 

--- a/Setup/shield-version-staging.txt
+++ b/Setup/shield-version-staging.txt
@@ -1,11 +1,11 @@
-#Build Staging:Build_249.5 on 14/01/18 #UNR
-SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:18.01-Build_249.5
+#Build Staging:Build_249.7 on 21/01/18 #UNR
+SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:18.01-Build_249.7
 shield-configuration:latest shield-configuration:171224-09.11-846
 shield-admin:latest shield-admin:249.4
 shield-portainer:latest shield-portainer:171217-11.30
 proxy-server:latest proxy-server:249.5 
-icap-server:latest icap-server:180107-16.00-951
-shield-cef:latest shield-cef:180107-16.00-951
+icap-server:latest icap-server:249.7
+shield-cef:latest shield-cef:249.7
 broker-server:latest broker-server:249.5
 shield-collector:latest shield-collector:180101-15.22-949
 shield-elk:latest shield-elk:171218-08.56-824


### PR DESCRIPTION
- Ignore upstream CA errors by default
- Cookies are off by default