### PR TITLE
Prod 280.3

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Action Required should have (!)
 
 ## [Unreleased]
+
+## [Prod:18.02-1-Build-280.3] - 2018-02-20
+### Enhancements:
+- Pre-check Installer Shield #2068
+- Pre-install check ubuntu and kernel version 
+- Added alert when system requires activation
+- Implement Keepalive with Votiro Server
+- Blacklist Policy rows should be also strikethrough
+- Publishing dynamic PAC files
+
+### Bug Fixes:
+- Duplicate Policies when using profiles (identified as a cookies issue)
+- Downloads of direct links do not work : "Download Disabled" message
+- Open new tab? notification is displayed when open link with middle click
+- Cross windows -booking.com
+- Emirates.com - Can't click on the website
+- Fixed rare broker crash
+- Remote Browsers are not starting after reboot
+- Activation: Key already in use
+- Admin takes long to load when no internet
+- The leader node IP displayed is 0.0.0.0
+- Prevent NTLM from crashing when wrong DC address
+- Admin - policies - default values are taken from the current profile in focus
+- Backup service is not running on the leader and user need to restore the data
+- Admin Dashboard with long urls
+- Open new tab? notification is displayed when open link with middle click
+
 ## [Dev:Build_286] - 2018-2-22
 - High Number of Critical Error Alert is confusing #2184
 - Admin: Add new profile - the Add button was disabled #2120

--- a/Setup/Shield-Changelog.md
+++ b/Setup/Shield-Changelog.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [Prod:18.02-1-Build-280.1] - 2018-02-18
+## [Prod:18.02-1-Build-280.3] - 2018-02-20
 ### Enhancements:
 - Pre-check Installer Shield #2068
 - Pre-install check ubuntu and kernel version 
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Open new tab? notification is displayed when open link with middle click
 - Cross windows -booking.com
 - Emirates.com - Can't click on the website
-
+- Fixed rare broker crash
 - Remote Browsers are not starting after reboot
 - Activation: Key already in use
 - Admin takes long to load when no internet

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,5 +1,5 @@
-#Build Prod_18.02-1:Build_280.2 on 18/02/18
-SHIELD_VER=8.0.0.latest SHIELD_VER=18.02:Build_280.2
+#Build Prod_18.02-1:Build_280.3 on 20/02/18
+SHIELD_VER=8.0.0.latest SHIELD_VER=18.02:Build_280.3
 #
 shield-configuration:latest shield-configuration:180207-18.32-1293
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
@@ -8,7 +8,7 @@ shield-portainer:latest shield-portainer:171217-11.30
 proxy-server:latest proxy-server:180130-10.49-1232
 icap-server:latest icap-server:180215-13.04-1391
 shield-cef:latest shield-cef:180207-20.45-1295
-broker-server:latest broker-server:180214-08.18-1353
+broker-server:latest broker-server:180220-08.44-1407
 shield-collector:latest shield-collector:180207-18.32-1293
 shield-elk:latest shield-elk:180204-18.31-1272
 extproxy:latest extproxy:180131-15.40-1253


### PR DESCRIPTION
### Enhancements:
- Pre-check Installer Shield #2068
- Pre-install check ubuntu and kernel version
- Added alert when system requires activation
- Implement Keepalive with Votiro Server
- Blacklist Policy rows should be also strikethrough
- Publishing dynamic PAC files

### Bug Fixes:
- Duplicate Policies when using profiles (identified as a cookies issue)
- Downloads of direct links do not work : "Download Disabled" message
- Open new tab? notification is displayed when open link with middle
click
- Cross windows -booking.com
- Emirates.com - Can't click on the website
- Fixed rare broker crash
- Remote Browsers are not starting after reboot
- Activation: Key already in use
- Admin takes long to load when no internet
- The leader node IP displayed is 0.0.0.0
- Prevent NTLM from crashing when wrong DC address
- Admin - policies - default values are taken from the current profile
in focus
- Backup service is not running on the leader and user need to restore
the data
- Admin Dashboard with long urls
- Open new tab? notification is displayed when open link with middle
click