### PR TITLE
Dev 288

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Action Required should have (!)
 
 ## [Unreleased]
+
+## [Dev:Build_288] - 2018-2-27
+- (*) Fix broker browser refresh (#2258)
+- No license message should be written to log once per day #2249
+- Speedtest container image #2137
+- OVA quick - reports section should not be displayed at the admin #2229
+- No license message should be written to log less #2249
+- ExperimentalUpload shield activations result to external database #2250
+- Going out of fullscreen, session is displayed on just a portion of the page #2255 
+- (*) Page is refreshed from time to time #1991
+- Fix setting used to block apps; fix icap same logic as authproxy #2251
+- Added Precheck for Kernel version , Memory
+
 ## [Dev:Build_287] - 2018-2-26
 - Fix arrows and backspace-like keys in IE #2237 #2188
 - Experimental Upload shield-stats to external database #2209

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,15 +1,15 @@
-#Build Dev:Build_287 on 26/02/18
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_287
+#Build Dev:Build_288 on 27/02/18
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_288
 shield-configuration:latest shield-configuration:180214-09.14-1357
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180226-16.37-1461
+shield-admin:latest shield-admin:180227-18.46-1479
 shield-portainer:latest shield-portainer:171217-11.30
 proxy-server:latest proxy-server:180130-10.49-1232
-icap-server:latest icap-server:180226-14.41-1460
-shield-cef:latest shield-cef:180222-12.59-1444
-broker-server:latest broker-server:180226-13.56-1458
+icap-server:latest icap-server:180227-15.31-1470
+shield-cef:latest shield-cef:180227-12.31-1463
+broker-server:latest broker-server:180227-16.34-1472
 shield-collector:latest shield-collector:180207-18.32-1293
-shield-elk:latest shield-elk:180221-11.41-1427
+shield-elk:latest shield-elk:180227-17.58-1477
 extproxy:latest extproxy:180131-15.40-1253
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180204-14.34-1264
 shield-cdr-controller:latest shield-cdr-controller:180220-08.44-1407
@@ -19,4 +19,4 @@ shield-authproxy:latest shield-authproxy:180222-15.05-1450
 node-installer:latest node-installer:180214-12.26
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
-speedtest:latest speedtest:180226-16.37-1461
+speedtest:latest speedtest:180227-14.10-1464


### PR DESCRIPTION
## [Dev:Build_288] - 2018-2-27
- (*) Fix broker browser refresh (#2258)
- No license message should be written to log once per day #2249
- Speedtest container image #2137
- OVA quick - reports section should not be displayed at the admin #2229
- No license message should be written to log less #2249
- ExperimentalUpload shield activations result to external database
#2250
- Going out of fullscreen, session is displayed on just a portion of
the page #2255
- (*) Page is refreshed from time to time #1991
- Fix setting used to block apps; fix icap same logic as authproxy #2251
- Added Precheck for Kernel version , Memory