### PR TITLE
Dev295

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Action Required should have (!)
 
 ## [Unreleased]
+
+## [Dev:Build_295] - 2018-3-14
+- keybaord fixes  #2242 #2144 #2191 #2243 #2257
+- Autoupdate on multi machin from old prod to current prod failed to update the version #2347
+- Download "Blocked" instead of "Failed" #2345
+- Printing Enabled/Disabled Policy (R2) #654
+- Exception List for https w/o Trusted Certificate (B2) #875
+- Update policies - Main issue #2335
+- Add FMS flag in the polices #2300
+- System should work even if ELK is not present #2195
+- korean space typing issue #2257
+- Korean - ctrl A doesn't work as expected #2243
+- Left arrow issue when using Japanese #2191
+- Japanese henkan key doesn't work as expected #2144
+- Korean duplicate issue #2242
+
 ## [Dev:Build_294] - 2018-3-13
 - Fixed type in version file
 

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,13 +1,13 @@
-#Build Dev:Build_294 on 13/03/18
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_294
-shield-configuration:latest shield-configuration:180214-09.14-1357
+#Build Dev:Build_295 on 14/03/18
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_295
+shield-configuration:latest shield-configuration:180313-12.12-1524
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180312-07.59-1515
+shield-admin:latest shield-admin:180314-16.11-1534
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180130-10.49-1232
-icap-server:latest icap-server:180312-12.07-1520
-shield-cef:latest shield-cef:180312-12.24-1522
-broker-server:latest broker-server:180312-12.24-1522
+icap-server:latest icap-server:180314-16.11-1534
+shield-cef:latest shield-cef:180314-16.11-1534
+broker-server:latest broker-server:180314-07.33-1528
 shield-collector:latest shield-collector:180207-18.32-1293
 shield-elk:latest shield-elk:180227-17.58-1477
 extproxy:latest extproxy:180131-15.40-1253


### PR DESCRIPTION
## [Dev:Build_295] - 2018-3-14
- keyboard fixes  #2242 #2144 #2191 #2243 #2257
- Autoupdate on multi machine from old prod to current prod failed to
update the version #2347
- Download "Blocked" instead of "Failed" #2345
- Printing Enabled/Disabled Policy (R2) #654
- Exception List for https w/o Trusted Certificate (B2) #875
- Update policies - Main issue #2335
- Add FMS flag in the polices #2300
- System should work even if ELK is not present #2195
- korean space typing issue #2257
- Korean - ctrl A doesn't work as expected #2243
- Left arrow issue when using Japanese #2191
- Japanese henkan key doesn't work as expected #2144
- Korean duplicate issue #2242