### PR TITLE
Dev301

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_301] - 2018-3-21
+- Added load-test page back to icap
+- Fixed Votiro not available alert #2447
+- Read systemID from Consul instead of accessing the secret file
+- Fixed tests paths (didn't work in "on-demand" mode) 
+- Updated texts in Admin for Votiro HA and Secure LDAP
+- Updated scale formula + delay in start
+- FMS - msep works cross-iframe, fix some crash 
+
 ## [Dev:Build_300] - 2018-3-20
 - FMS - allow server play if client playing #1872 #2298
 - FMS - Cache codec support client-side #1872

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,18 +1,18 @@
-#Build Dev:Build_300 on 18/03/20
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_300
+#Build Dev:Build_301 on 18/03/21
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_301
 shield-configuration:latest shield-configuration:180313-12.12-1524
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180320-16.40-1606
+shield-admin:latest shield-admin:180321-08.41-1609
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180320-14.57-1598
-icap-server:latest icap-server:180320-16.19-1603
-shield-cef:latest shield-cef:180320-16.40-1606
-broker-server:latest broker-server:180320-16.40-1606
-shield-collector:latest shield-collector:180319-09.25-1564
+icap-server:latest icap-server:180321-15.47-1617
+shield-cef:latest shield-cef:180321-15.47-1617
+broker-server:latest broker-server:180321-16.09-1618
+shield-collector:latest shield-collector:180321-13.52-1615
 shield-elk:latest shield-elk:180315-09.27-1544
 extproxy:latest extproxy:180320-14.57-1598
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180320-16.40-1606
-shield-cdr-controller:latest shield-cdr-controller:180320-14.09-1595
+shield-cdr-controller:latest shield-cdr-controller:180321-11.36-1611
 shield-web-service:latest shield-web-service:180204-14.34-1264
 shield-maintenance:latest shield-maintenance:171015-11.48-270
 shield-authproxy:latest shield-authproxy:180320-16.40-1606


### PR DESCRIPTION
## [Dev:Build_301] - 2018-3-21
- Added load-test page back to icap
- Fixed Votiro not available alert #2447
- Read systemID from Consul instead of accessing the secret file
- Fixed tests paths (didn't work in "on-demand" mode)
- Updated texts in Admin for Votiro HA and Secure LDAP
- Updated scale formula + delay in start
- FMS - msep works cross-iframe, fix some crash