### PR TITLE
Staging18-04-Build-312.1

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Staging:18.04-Staging:Build_312.1] - 2018-4-11
+- Chrome version used by shield should be updated #2662
+- Allow IE11 with compat user agent (inc. apps)
+- The broker should not start before main browser service? #2681
+- Scale to should not be executed in case shield is not activated #2614
+- Scaleto can bypass the system capacity #2576
+- Scale to is being skipped and no new service is created when it should #2575
+- Change the "scale to" formula #2542
+
 ## [Dev:Build_316] - 2018-4-10
 - Intercept and proxy 'mailto' links  #1276
 - Admin - Analyzer - Fixed Run Client Analyzer address #2619

--- a/Setup/shield-version-staging.txt
+++ b/Setup/shield-version-staging.txt
@@ -1,14 +1,14 @@
-#Build Staging:18.04-Build_312 on 05/04/18
+#Build Staging:18.04-Build_312.1 on 11/04/18
 #
-SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:18.04-Build_312
+SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:18.04-Build_312.1
 shield-configuration:latest shield-configuration:180313-12.12-1524
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180402-09.46-1751
+shield-admin:latest shield-admin:Staging18.4.312.2
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180326-17.47-1705
-icap-server:latest icap-server:180326-18.12-1709
-shield-cef:latest shield-cef:180404-12.04-1755
-broker-server:latest broker-server:180327-12.08-1723
+icap-server:latest icap-server:Staging18.4.312.2
+shield-cef:latest shield-cef:Staging18.4.312.1
+broker-server:latest broker-server:Staging18.4.312.2
 shield-collector:latest shield-collector:180328-12.39-1738
 shield-elk:latest shield-elk:180327-14.28-1725
 extproxy:latest extproxy:180320-14.57-1598


### PR DESCRIPTION
## [Staging:18.04-Staging:Build_312.1] - 2018-4-11
- Chrome version used by shield should be updated #2662
- Allow IE11 with compat user agent (inc. apps)
- The broker should not start before main browser service? #2681
- Scale to should not be executed in case shield is not activated #2614
- Scaleto can bypass the system capacity #2576
- Scale to is being skipped and no new service is created when it
should #2575
- Change the "scale to" formula #2542