### PR TITLE
Dev 319

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
+## [Dev:Build_319] - 2018-4-16
+- Add new profile -fix tab functionality to navigate to "Add" button #2342
+- change the "scale to" formula #2542
+- Scaleto can bypass the system capacity #2576
+- Periodic Test should be configurable #2580
+- Scale to should not be executed in case shield is not activated #2614
+- Update from prod to staging should copy all files #2661
+- Should override key pairs file when generate ./update.sh ssthkey #2669
+- The broker should not start before main browser service? #2681
+- When reboot shield machine, the broker doesn't wait for the main browser service #2698
+- Uptoupdate did not work #2702
+- Auth Proxy - set ipv4 dns first
+
+
 ## [Dev:Build_318] - 2018-4-15
 - Admin - FQDN is updated - add pop up message and reload page #2690
 - Block ftp protocol - not shield it #2689

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,15 +1,15 @@
-#Build Dev:Build_318 on 18/04/15
+#Build Dev:Build_319 on 18/04/16
 #
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_318
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_319
 shield-configuration:latest shield-configuration:180409-12.08-1774
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180415-07.00-1823
+shield-admin:latest shield-admin:180416-13.33-1834
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180326-17.47-1705
 icap-server:latest icap-server:180415-11.05-1827
-shield-cef:latest shield-cef:180415-11.05-1827
-broker-server:latest broker-server:180415-08.29-1825
-shield-collector:latest shield-collector:180412-12.30-1815
+shield-cef:latest shield-cef:180416-10.16-1830
+broker-server:latest broker-server:180416-10.16-1830
+shield-collector:latest shield-collector:180416-12.37-1832
 shield-elk:latest shield-elk:180327-14.28-1725
 extproxy:latest extproxy:180320-14.57-1598
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180320-16.40-1606
@@ -21,5 +21,5 @@ node-installer:latest node-installer:180214-12.26
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:180312-09.40-1517
-shield-autoupdate:latest shield-autoupdate:180410-14.55-1789
+shield-autoupdate:latest shield-autoupdate:180416-14.10-1836
 shield-notifier:latest shield-notifier:180412-11.35-1809


### PR DESCRIPTION
## [Dev:Build_319] - 2018-4-16
- Add new profile -fix tab functionality to navigate to "Add" button
#2342
- change the "scale to" formula #2542
- Scaleto can bypass the system capacity #2576
- Periodic Test should be configurable #2580
- Scale to should not be executed in case shield is not activated #2614
- Update from prod to staging should copy all files #2661
- Should override key pairs file when generate ./update.sh ssthkey #2669
- The broker should not start before main browser service? #2681
- When reboot shield machine, the broker doesn't wait for the main
browser service #2698
- Uptoupdate did not work #2702
- Auth Proxy - set ipv4 dns first