### PR TITLE
Dev 325

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Action Required should have (!)
 
 ## [Unreleased]
+## [Dev:Build_325] - 2018-4-24
+- Allow already connected users even if license limit #2717
+- No alert when DNS is down #2758
+- Small fix for warning/error levels for #2781
+- License logic - can't open more tabs after reach to max license #2717
+- Pre check install shows duplicate for warning and faulire and no ranges for drive speed #2781
+- Pre check install script - please add the normal, warning and failure ranges #2515
+- Add "Refresh AD Cache" button to the Admin UI #2696
 
 ## [Dev:Build_324] - 2018-4-23
 - Pre check install script -the memory test prints ok for 8GB #2761

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,22 +1,22 @@
-#Build Dev:Build_324 on 18/04/23
+#Build Dev:Build_325 on 18/04/24
 #
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_324
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_325
 shield-configuration:latest shield-configuration:180409-12.08-1774
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180423-08.28-1857
+shield-admin:latest shield-admin:180424-15.53-1871
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180326-17.47-1705
-icap-server:latest icap-server:180420-13.41-1854
+icap-server:latest icap-server:180424-08.55-1866
 shield-cef:latest shield-cef:180417-13.43-1848
 broker-server:latest broker-server:180422-06.06-1855
-shield-collector:latest shield-collector:180423-15.26-1863
+shield-collector:latest shield-collector:180424-13.40-1869
 shield-elk:latest shield-elk:180423-08.28-1857
 extproxy:latest extproxy:180320-14.57-1598
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180320-16.40-1606
 shield-cdr-controller:latest shield-cdr-controller:180321-11.36-1611
 shield-web-service:latest shield-web-service:180326-13.17-1688
 shield-maintenance:latest shield-maintenance:171015-11.48-270
-shield-authproxy:latest shield-authproxy:180420-13.41-1854
+shield-authproxy:latest shield-authproxy:180424-15.53-1871
 node-installer:latest node-installer:180214-12.26
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026


### PR DESCRIPTION
## [Dev:Build_325] - 2018-4-24
- Allow already connected users even if license limit #2717
- No alert when DNS is down #2758
- Small fix for warning/error levels for #2781
- License logic - can't open more tabs after reach to max license #2717
- Pre check install shows duplicate for warning and faulire and no
ranges for drive speed #2781
- Pre check install script - please add the normal, warning and failure
ranges #2515
- Add "Refresh AD Cache" button to the Admin UI #2696