### PR TITLE
Fix installer fly when docker command use with slim-jessie base image

### DIFF
--- a/SetupNode/Dockerfile
+++ b/SetupNode/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.6.5-slim-jessie
 
-
+RUN apt-get update && apt-get install -y libltdl7
 RUN pip install --upgrade pip
-
 
 COPY scripts /scripts
 COPY setup-node.sh /


### PR DESCRIPTION
Will fix
https://github.com/EricomSoftwareLtd/SB/issues/2886
and
https://github.com/EricomSoftwareLtd/SB/issues/2892