### PR TITLE
Staging18.05-Build_331

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Staging:18.05-Staging:Build_331] - 2018-5-06
+- When cache is enabled it behave as a proxy and XFF list contain cef IP #2877
+- Block ftp protocol - not shield it #2689
+- Allow blacklist req in authproxy #2889
+- Bugfix the alerts settings are removed #2893
+- install-certificate now provide the real CA certificate 
+- Remote Browser will write log per level set in the Admin - reduce logs 
+- Analyzer Report #2865
+- Log Apps request #2325
+
 ## [Dev:Build_331] - 2018-5-3
 - When cache is enabled it behave as a proxy and XFF list contain cef IP #2877
 - Block ftp protocol - not shield it #2689

--- a/Setup/shield-version-staging.txt
+++ b/Setup/shield-version-staging.txt
@@ -1,18 +1,18 @@
-#Build Staging:18.05-Build_330 on 04/05/18
+#Build Staging:18.05-Build_331 on 06/05/18
 #
-SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:18.05-Build_330
+SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:18.05-Build_331
 #docker-version 18.03.0
 shield-configuration:latest shield-configuration:180502-13.04-1933
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180502-21.23-1944
+shield-admin:latest shield-admin:180503-15.42-1967
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180501-10.20-1917
-icap-server:latest icap-server:180502-14.51-1937
-shield-cef:latest shield-cef:180502-21.11-1943
-broker-server:latest broker-server:180502-21.11-1943
+icap-server:latest icap-server:180503-11.29-1956
+shield-cef:latest shield-cef:180503-11.29-1956
+broker-server:latest broker-server:180503-12.11-1958
 shield-collector:latest shield-collector:180501-11.57-1919
-shield-elk:latest shield-elk:180429-10.32-1893
-extproxy:latest extproxy:180320-14.57-1598
+shield-elk:latest shield-elk:180503-14.33-1961
+extproxy:latest extproxy:180503-08.45-1951
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180320-16.40-1606
 shield-cdr-controller:latest shield-cdr-controller:180321-11.36-1611
 shield-web-service:latest shield-web-service:180326-13.17-1688
@@ -23,5 +23,5 @@ shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:180312-09.40-1517
 shield-autoupdate:latest shield-autoupdate:180502-14.51-1937
-shield-notifier:latest shield-notifier:180502-13.55-1934
+shield-notifier:latest shield-notifier:180503-15.42-1967
 # This needs to be the last line


### PR DESCRIPTION
## [Staging:18.05-Staging:Build_331] - 2018-5-06
- When cache is enabled it behave as a proxy and XFF list contain cef
IP #2877
- Block ftp protocol - not shield it #2689
- Allow blacklist req in authproxy #2889
- Bugfix the alerts settings are removed #2893
- install-certificate now provide the real CA certificate
- Remote Browser will write log per level set in the Admin - reduce
logs
- Analyzer Report #2865
- Log Apps request #2325