### PR TITLE
Dev 333

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Action Required should have (!)
 
 ## [Unreleased]
+## [Dev:Build_333] - 2018-5-10
+- FPS idel time out should be limited for foreground only #2901
+- Send Anonymous Feedback - false by default
+- When not typing the full URL, redirect fails (Reported by BTL) #2853
+- Upload shield status once per 24 hours. Include stats sampled once an hour #2938
+- Consul back up restore failed #2827
+- Update node to the latest LTS (currently 8.x)
+- Better Alert mail texts #2941
+- Mail support list of recipients
+- Ext proxy support for ADBlock, DNS caching and Using direct 
+- Application issue in Admin UI #2959
+- Resources Saver Timeout (min) - change location at the admin #2947
+- Admin UI for DNS and Ad-blocks #2940
+- Idle timeout - Not working #2954
+- Write shield stats to ELK
+- Suspend forground tabs #2946
+- Applications -default and override rules do not support multi profile #2937
+- Apps support in Shield #1525
+- DNS resolving is not cached when using caching (Ext proxy) #2793
+- Store Connection Pref report in ELK #2986
+
 
 ## [Dev:Build_332] - 2018-5-8
 - Admin - loading indicator always on - error on page #2866

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,26 +1,26 @@
-#Build Dev:Build_332 on 18/05/8
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_332
+#Build Dev:Build_333 on 18/05/10
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_333
 #docker-version 18.03.0
-shield-configuration:latest shield-configuration:180502-13.04-1933
+shield-configuration:latest shield-configuration:180510-10.17-2023
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180508-10.39-1994
+shield-admin:latest shield-admin:180510-14.46-2033
 shield-portainer:latest shield-portainer:180311-14.35-1498
-proxy-server:latest proxy-server:180508-13.37-1998
-icap-server:latest icap-server:180508-12.13-1996
-shield-cef:latest shield-cef:180508-08.51-1990
-broker-server:latest broker-server:180508-13.37-1998
+proxy-server:latest proxy-server:180510-08.33-2016
+icap-server:latest icap-server:180510-10.39-2025
+shield-cef:latest shield-cef:180510-16.16-2039
+broker-server:latest broker-server:180510-14.33-2031
 shield-collector:latest shield-collector:180501-11.57-1919
-shield-elk:latest shield-elk:180503-14.33-1961
-extproxy:latest extproxy:180508-13.37-1998
+shield-elk:latest shield-elk:180510-16.45-2042
+extproxy:latest extproxy:180510-08.33-2016
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180320-16.40-1606
 shield-cdr-controller:latest shield-cdr-controller:180321-11.36-1611
 shield-web-service:latest shield-web-service:180326-13.17-1688
 shield-maintenance:latest shield-maintenance:171015-11.48-270
-shield-authproxy:latest shield-authproxy:180504-14.42-1969
+shield-authproxy:latest shield-authproxy:180510-08.13-2015
 node-installer:latest node-installer:180503-17.04
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:180312-09.40-1517
 shield-autoupdate:latest shield-autoupdate:180502-14.51-1937
-shield-notifier:latest shield-notifier:180503-15.42-1967
+shield-notifier:latest shield-notifier:180509-13.57-2011
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_333] - 2018-5-10
- FPS idel time out should be limited for foreground only #2901
- Send Anonymous Feedback - false by default
- When not typing the full URL, redirect fails (Reported by BTL) #2853
- Upload shield status once per 24 hours. Include stats sampled once an
hour #2938
- Consul back up restore failed #2827
- Update node to the latest LTS (currently 8.x)
- Better Alert mail texts #2941
- Mail support list of recipients
- Ext proxy support for ADBlock, DNS caching and Using direct
- Application issue in Admin UI #2959
- Resources Saver Timeout (min) - change location at the admin #2947
- Admin UI for DNS and Ad-blocks #2940
- Idle timeout - Not working #2954
- Write shield stats to ELK
- Suspend forground tabs #2946
- Applications -default and override rules do not support multi profile
#2937
- Apps support in Shield #1525
- DNS resolving is not cached when using caching (Ext proxy) #2793
- Store Connection Pref report in ELK #2986