### PR TITLE
Dev 335

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_335] - 2018-5-14
+- On ext-proxy internal-dns servers should be used when no ext-servers are specified #3014
+- Support per node alerts ( for CPU, Memory , Disk ) #3006
+- DNS settings at the admin should be limited only to IP address #3001
+- Alert when DNS setting are not set #2980
+- Minimised view of page after reloading or opening new tab in Firefox on Linux machine. #2961
+- Can't create new account for google drive with shield #2944
+- Add an alert when disk is low for storing the logs #2824
+- Browser service restart policy is set to none in -quickeval #2958
+- Improve setting init zoom #2961 #2992
+- Nameservers are not set from resolv.conf #3015
+- Updated jp translation file
+- Support for Apps that cant authenticate - backend side 
+
+
 ## [Dev:Build_334] - 2018-5-13
 - Proxies will use dns container #2969
 - (*) Fix blank child windows #2968

--- a/Setup/shield-version-dev.txt
+++ b/Setup/shield-version-dev.txt
@@ -1,27 +1,27 @@
-#Build Dev:Build_334 on 18/05/13
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_334
+#Build Dev:Build_335 on 18/05/14
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_335
 #docker-version 18.03.0
 shield-configuration:latest shield-configuration:180510-10.17-2023
 shield-consul-agent:latest shield-consul-agent:180207-18.32-1293
-shield-admin:latest shield-admin:180510-14.46-2033
+shield-admin:latest shield-admin:180514-14.16-2093
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180513-09.47-2055
-icap-server:latest icap-server:180513-11.00-2064
-shield-cef:latest shield-cef:180513-09.24-2053
-broker-server:latest broker-server:180513-13.02-2072
+icap-server:latest icap-server:180514-14.25-2094
+shield-cef:latest shield-cef:180514-13.11-2090
+broker-server:latest broker-server:180514-14.25-2094
 shield-collector:latest shield-collector:180501-11.57-1919
-shield-elk:latest shield-elk:180510-16.45-2042
-extproxy:latest extproxy:180513-13.38-2074
+shield-elk:latest shield-elk:180514-13.11-2090
+extproxy:latest extproxy:180514-13.54-2092
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180320-16.40-1606
 shield-cdr-controller:latest shield-cdr-controller:180321-11.36-1611
 shield-web-service:latest shield-web-service:180326-13.17-1688
 shield-maintenance:latest shield-maintenance:171015-11.48-270
-shield-authproxy:latest shield-authproxy:180513-12.50-2070
+shield-authproxy:latest shield-authproxy:180514-14.25-2094
 node-installer:latest node-installer:180503-17.04
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:180312-09.40-1517
 shield-autoupdate:latest shield-autoupdate:180502-14.51-1937
-shield-notifier:latest shield-notifier:180509-13.57-2011
+shield-notifier:latest shield-notifier:180514-13.11-2090
 shield-dns:latest shield-dns:180513-10.50-2062
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_335] - 2018-5-14
- On ext-proxy internal-dns servers should be used when no ext-servers
are specified #3014
- Support per node alerts ( for CPU, Memory , Disk ) #3006
- DNS settings at the admin should be limited only to IP address #3001
- Alert when DNS setting are not set #2980
- Minimised view of page after reloading or opening new tab in Firefox
on Linux machine. #2961
- Can't create new account for google drive with shield #2944
- Add an alert when disk is low for storing the logs #2824
- Browser service restart policy is set to none in -quickeval #2958
- Improve setting init zoom #2961 #2992
- Nameservers are not set from resolv.conf #3015
- Updated jp translation file
- Support for Apps that cant authenticate - backend side