### PR TITLE
Do not use hostname for the dns service

### DIFF
--- a/Setup/docker-compose_dev.yml
+++ b/Setup/docker-compose_dev.yml
@@ -8,7 +8,6 @@ services:
     image: securebrowsing/shield-dns:latest
     networks:
       - shield
-    hostname: dns
     deploy:
       replicas: 2
       restart_policy:


### PR DESCRIPTION
Do not use hostname for the dns service because it hampers correct registration in Consul: service is uniquely identified by its name and hostname and if the two are same for all containers only one instance of the service will be registered.