### PR TITLE
Dev 365

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_365] - 2018-7-2
+- Default ntlm fallback set to false. removed --verbose
+- Japanese press escape while in composition mode makes copies of text
+- Japanese key combinations: space after shift+kanji #2874
+
 ## [Dev:Build_364] - 2018-6-28
 - drop-down values do not work properly #3543 1.8.7 
 - status doesnt work #3572

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,14 +1,14 @@
-#Build Dev:Build_364.1 on 18/06/28
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_364.1
+#Build Dev:Build_365 on 18/07/2
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_365
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:180610-14.23-2329
 shield-consul-agent:latest shield-consul-agent:180606-12.58-2298
-shield-admin:latest shield-admin:180626-12.17-2456
+shield-admin:latest shield-admin:180702-09.53-2473
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180613-09.19-2372
-icap-server:latest icap-server:180627-12.08-2458
+icap-server:latest icap-server:180702-09.25-2472
 shield-cef:latest shield-cef:180628-13.27-2467
-broker-server:latest broker-server:180625-12.32-2450
+broker-server:latest broker-server:180702-09.53-2473
 shield-collector:latest shield-collector:180628-10.28-2462
 shield-elk:latest shield-elk:180619-13.19-2419
 extproxy:latest extproxy:180608-11.56-2317


### PR DESCRIPTION
## [Dev:Build_365] - 2018-7-2
- Default ntlm fallback set to false. removed --verbose
- Japanese press escape while in composition mode makes copies of text
- Japanese key combinations: space after shift+kanji #2874