### PR TITLE
Dev 373

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_373] - 2018-7-17
+- CDR: Consider showing file block reason to the user, based on the report #1360
+- Fix auth proxy crash on LDAP refresh in Admin
+
 ## [Dev:Build_372] - 2018-7-16
 - Notifiy end user when page load is slow (18.06) #3011
 - Several components updates

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,22 +1,22 @@
-#Build Dev:Build_372 on 18/07/16
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_372
+#Build Dev:Build_373 on 18/07/17
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_373
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:180610-14.23-2329
 shield-consul-agent:latest shield-consul-agent:180606-12.58-2298
-shield-admin:latest shield-admin:180716-12.30-2538
+shield-admin:latest shield-admin:180717-16.51-2548
 shield-portainer:latest shield-portainer:180311-14.35-1498
 proxy-server:latest proxy-server:180613-09.19-2372
 icap-server:latest icap-server:180716-13.37-2540
-shield-cef:latest shield-cef:180712-12.32-2517
+shield-cef:latest shield-cef:180717-16.37-2546
 broker-server:latest broker-server:180716-08.06-2529
 shield-collector:latest shield-collector:180716-07.30-2527
 shield-elk:latest shield-elk:180716-11.13-2533
 extproxy:latest extproxy:180608-11.56-2317
-shield-cdr-dispatcher:latest shield-cdr-dispatcher:180712-12.46-2518
-shield-cdr-controller:latest shield-cdr-controller:180716-07.30-2527
+shield-cdr-dispatcher:latest shield-cdr-dispatcher:180717-16.37-2546
+shield-cdr-controller:latest shield-cdr-controller:180717-16.37-2546
 shield-web-service:latest shield-web-service:180618-13.09-2408
 shield-maintenance:latest shield-maintenance:180620-10.35-2427
-shield-authproxy:latest shield-authproxy:180716-07.30-2527
+shield-authproxy:latest shield-authproxy:180717-14.56-2545
 node-installer:latest node-installer:180503-17.04
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026


### PR DESCRIPTION
## [Dev:Build_373] - 2018-7-17
- CDR: Consider showing file block reason to the user, based on the
report #1360
- Fix auth proxy crash on LDAP refresh in Admin