### PR TITLE
Staging384

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Staging:18.08-Staging:Build_384] - 2018-8-07
+- Certain scribed URL takes a long time to load (sometime after 30 to 60 seconds and sometimes it did NOT load at all after few minutes) #3842
+- Patch for Timeout occur during join new node to cluster #3840
+- Japanese Strings for 18.08 (from KKA)
+- BTL: Disk on Management Nodes is fills up very quickly #3804
+- Limit Logs for ELK
+- Loaded dictionary for locale us-en Error #3833
+- Route all traffic (including white-listed) via the Browser farm #3654
+- After adding nodes all confiugration is lost #3813
+- Votiro: Include Votiro dynamic information reason (untranslated) in the tooltip #3837
+- Backup are not generated sometimes #3844
+- Certain scribed URL takes a long time to load
+- Dropdown issue #3797
+- [[Investigation]] QA#687503 It is strange to print PDF #110
+- Incorrect node join to cluster block addnode script operation #3825
+- The file is being download but also I get an error #3794
+- Add error for the user in case some or all files inside a zip file is being blocked #3808
+- When download virus inside a zip protected with password the message is incorrect #3809
+- Route all traffic (including white-listed) via the Browser farm #3654
+- Fix download docker images on slave nodes
+- After adding nodes all confiugration is lost #3813
+
 ## [Dev:Build_383] - 2018-08-06
 - Patch for Timeout occur during join new node to cluster #3840
 

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,27 +1,27 @@
-#Build Staging:Build_378 on 18/07/30
-SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:Build_378
+#Build Staging:Build_384 on 18/08/07
+SHIELD_VER=8.0.0.latest SHIELD_VER=Staging:Build_384
 #docker-version 18.03.1
-shield-configuration:latest shield-configuration:180610-14.23-2329
+shield-configuration:latest shield-configuration:180802-08.24-2604
 shield-consul-agent:latest shield-consul-agent:180606-12.58-2298
-shield-admin:latest shield-admin:180729-11.31-2581
+shield-admin:latest shield-admin:180805-10.01-2613
 shield-portainer:latest shield-portainer:180723-05.33-2570
-proxy-server:latest proxy-server:180718-20.17-2554
-icap-server:latest icap-server:180726-10.55-2580
-shield-cef:latest shield-cef:180726-09.42-2578
-broker-server:latest broker-server:180726-09.42-2578
+proxy-server:latest proxy-server:180807-07.48-2618
+icap-server:latest icap-server:180802-13.04-2609
+shield-cef:latest shield-cef:180802-09.09-2606
+broker-server:latest broker-server:180801-08.45-2596
 shield-collector:latest shield-collector:180716-07.30-2527
 shield-elk:latest shield-elk:180730-12.48-2584
 extproxy:latest extproxy:180730-13.51-2586
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:180717-16.37-2546
-shield-cdr-controller:latest shield-cdr-controller:180717-16.37-2546
+shield-cdr-controller:latest shield-cdr-controller:180801-14.32-2599
 shield-web-service:latest shield-web-service:180618-13.09-2408
 shield-maintenance:latest shield-maintenance:180620-10.35-2427
-shield-authproxy:latest shield-authproxy:180717-14.56-2545
+shield-authproxy:latest shield-authproxy:180801-08.45-2596
 node-installer:latest node-installer:180503-17.04
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:180606-12.58-2298
-shield-autoupdate:latest shield-autoupdate:180711-14.26-2510
+shield-autoupdate:latest shield-autoupdate:180806-13.28-2614
 shield-notifier:latest shield-notifier:180618-13.09-2408
 shield-dns:latest shield-dns:180712-09.14-2514
 # This needs to be the last line


### PR DESCRIPTION
## [Staging:18.08-Staging:Build_384] - 2018-8-07
- Certain scribed URL takes a long time to load (sometime after 30 to
60 seconds and sometimes it did NOT load at all after few minutes) #3842
- Patch for Timeout occur during join new node to cluster #3840
- Japanese Strings for 18.08 (from KKA)
- BTL: Disk on Management Nodes is fills up very quickly #3804
- Limit Logs for ELK
- Loaded dictionary for locale us-en Error #3833
- Route all traffic (including white-listed) via the Browser farm #3654
- After adding nodes all configuration is lost #3813
- Votiro: Include Votiro dynamic information reason (untranslated) in
the tooltip #3837
- Backup are not generated sometimes #3844
- Certain scribed URL takes a long time to load
- Dropdown issue #3797
- [[Investigation]] QA#687503 It is strange to print PDF #110
- Incorrect node join to cluster block addnode script operation #3825
- The file is being download but also I get an error #3794
- Add error for the user in case some or all files inside a zip file is
being blocked #3808
- When download virus inside a zip protected with password the message
is incorrect #3809
- Route all traffic (including white-listed) via the Browser farm #3654
- Fix download docker images on slave nodes
- After adding nodes all configuration is lost #3813