### PR TITLE
Dev 400

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Proxy message should not allow blanks #4090
 - Several improvements for page loading 
 - Round down to supported resolutions
+- add --verbose to addnodes usage menu #3596
+- Votiro New Version #4128
+- SalesForce - issues with user story -need to click few times to open user story #4041
+- saleforce.com/ Cannot export to excel ("Download failed" error message) #2158
+- salesforce - user story text is not wrapped #4040
+- set end user translations is not working #4129
+
 
 ## [Dev:Build_399] - 2018-09-04
 - Fix IME position 

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_400] - 2018-09-06
+- Missing Important Time Values in the Reports #1418
+- New window dialog should open when clicking outside #4123
+- Admin loading indicator doesn't disappear #4108
+- Some components stopped communicate with the consul on specific machine #4087
+- Failed to create cluster using Staging 396 #4084
+- Ericom shield scripts should be consistent #4082
+- Update.sh should give an error in case I use bad parameter #4081
+- 502 bad gateway- can't access to admin on specific machine #4069
+- ./restore.sh add a menu usage #4068
+- daf-yomi.com - pdf viewer bad fonts #4060
+- Search with Google should truncate the text #4058
+- Don't run pre-check on update by default #4036
+- Fonts issue excel online #4005
+- Check consul communication - make sure we don't send to much data #3978
+- Pause Shield & Reload #3955
+- Authproxy fails to start because of bad config #3898
+- LDAP admin login - when I change the Authentication settings the display for ldap admin not updated #3873
+- Kan Radio audio volume is mute and cannot be changed #3792
+- Add prepare-node.sh as part of addnode script #3616
+- LDAP admin login - change the AD group but the save button remain disabled #3925
+- Apply health check for consul
+- Proxy message should not allow blanks #4090
+- Several improvements for page loading 
+- Round down to supported resolutions
+
 ## [Dev:Build_399] - 2018-09-04
 - Fix IME position 
 

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,27 +1,27 @@
-#Build Dev:Build_399 on 18/09/04
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_399
+#Build Dev:Build_400 on 18/09/06
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_400
 #docker-version 18.03.1
-shield-configuration:latest shield-configuration:180826-12.52-2731
-shield-consul-agent:latest shield-consul-agent:180819-13.00-2666
-shield-admin:latest shield-admin:180903-10.05-2754
+shield-configuration:latest shield-configuration:180906-15.52-2783
+shield-consul-agent:latest shield-consul-agent:180906-15.52-2783
+shield-admin:latest shield-admin:180906-17.10-2788
 shield-portainer:latest shield-portainer:180807-14.18-2623
 proxy-server:latest proxy-server:180822-11.30-2699
-icap-server:latest icap-server:180904-09.44-2758
-shield-cef:latest shield-cef:180904-09.44-2758
-broker-server:latest broker-server:180828-10.21-2744
-shield-collector:latest shield-collector:180812-07.22-2643
-shield-elk:latest shield-elk:180822-10.12-2696
-extproxy:latest extproxy:180822-11.30-2699
-shield-cdr-dispatcher:latest shield-cdr-dispatcher:180819-09.04-2662
-shield-cdr-controller:latest shield-cdr-controller:180819-09.04-2662
-shield-web-service:latest shield-web-service:180819-09.04-2662
-shield-maintenance:latest shield-maintenance:180620-10.35-2427
-shield-authproxy:latest shield-authproxy:180828-10.21-2744
+icap-server:latest icap-server:180906-15.29-2782
+shield-cef:latest shield-cef:180906-15.29-2782
+broker-server:latest broker-server:180906-15.29-2782
+shield-collector:latest shield-collector:180906-16.12-2785
+shield-elk:latest shield-elk:180906-15.29-2782
+extproxy:latest extproxy:180906-17.10-2788
+shield-cdr-dispatcher:latest shield-cdr-dispatcher:180906-16.46-2787
+shield-cdr-controller:latest shield-cdr-controller:180906-16.46-2787
+shield-web-service:latest shield-web-service:180906-16.46-2787
+shield-maintenance:latest shield-maintenance:180906-15.52-2783
+shield-authproxy:latest shield-authproxy:180906-15.29-2782
 node-installer:latest node-installer:180503-17.04
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:180606-12.58-2298
-shield-autoupdate:latest shield-autoupdate:180826-12.52-2731
-shield-notifier:latest shield-notifier:180819-09.04-2662
-shield-dns:latest shield-dns:180819-09.04-2662
+shield-autoupdate:latest shield-autoupdate:180906-14.38-2781
+shield-notifier:latest shield-notifier:180906-15.29-2782
+shield-dns:latest shield-dns:180906-07.29-2763
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_400] - 2018-09-06
- Missing Important Time Values in the Reports #1418
- New window dialog should open when clicking outside #4123
- Admin loading indicator doesn't disappear #4108
- Some components stopped communicate with the consul on specific
machine #4087
- Failed to create cluster using Staging 396 #4084
- Ericom shield scripts should be consistent #4082
- Update.sh should give an error in case I use bad parameter #4081
- 502 bad gateway- can't access to admin on specific machine #4069
- ./restore.sh add a menu usage #4068
- daf-yomi.com - pdf viewer bad fonts #4060
- Search with Google should truncate the text #4058
- Don't run pre-check on update by default #4036
- Fonts issue excel online #4005
- Check consul communication - make sure we don't send to much data
#3978
- Pause Shield & Reload #3955
- Authproxy fails to start because of bad config #3898
- LDAP admin login - when I change the Authentication settings the
display for ldap admin not updated #3873
- Kan Radio audio volume is mute and cannot be changed #3792
- Add prepare-node.sh as part of addnode script #3616
- LDAP admin login - change the AD group but the save button remain
disabled #3925
- Apply health check for consul
- Proxy message should not allow blanks #4090
- Several improvements for page loading
- Round down to supported resolutions