### PR TITLE
Dev 422

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_422] - 2018-10-23
+- Standby remote browser under admin ui > resources #2578
+- No alert about votiro bad address when using upstream proxy #4047
+- Change Text on Send Feedback #4384
+- Incorrect title after the policies was imported #4395
+- Update default CA date #4401
+- link for details - no results found #4424
+- Consul backup is taking a lot of CPU #4433
+- Facebook playing videos #4440
+- Alert are keep being sent about AD groups conflict #4443
+- CDR controller sometimes - failed firing event #4498
+- The version is missing in the Login - About screen #4259
+- admin UI - error message when it should not be displayed #4369
+- Wrong error messages displayed when trying to change a domain name with an incorrect one #4400
+- The activation key is not removed after the activation is done #3232
+- Admin UI - save should auto-remove spaces when exists #3331
+
 ## [Dev:Build_421] - 2018-10-21
 - No mail alert on a machine with upstream proxy #4477
 - Download big pdf file fails with timeout #4444

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,19 +1,19 @@
-#Build Dev:Build_421 on 18/10/21
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_421
+#Build Dev:Build_422 on 18/10/23
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_422
 #docker-version 18.03.1
-shield-configuration:latest shield-configuration:181018-11.29-3005
+shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:181021-12.38-3020
+shield-admin:latest shield-admin:181023-11.39-3033
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181015-10.49-2967
-icap-server:latest icap-server:181021-12.04-3018
-shield-cef:latest shield-cef:181021-06.29-3013
-broker-server:latest broker-server:181021-07.35-3015
+icap-server:latest icap-server:181022-20.45-3029
+shield-cef:latest shield-cef:181022-20.45-3029
+broker-server:latest broker-server:181023-10.29-3030
 shield-collector:latest shield-collector:181021-13.12-3023
 shield-elk:latest shield-elk:181017-09.51-2993
 extproxy:latest extproxy:181010-18.49-2935
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:181010-18.49-2935
-shield-cdr-controller:latest shield-cdr-controller:181021-13.02-3021
+shield-cdr-controller:latest shield-cdr-controller:181023-10.29-3030
 shield-web-service:latest shield-web-service:181015-10.29-2966
 shield-maintenance:latest shield-maintenance:181010-18.49-2935
 shield-authproxy:latest shield-authproxy:181011-12.20-2952


### PR DESCRIPTION
## [Dev:Build_422] - 2018-10-23
- Standby remote browser under admin ui > resources #2578
- No alert about votiro bad address when using upstream proxy #4047
- Change Text on Send Feedback #4384
- Incorrect title after the policies was imported #4395
- Update default CA date #4401
- link for details - no results found #4424
- Consul backup is taking a lot of CPU #4433
- Facebook playing videos #4440
- Alert are keep being sent about AD groups conflict #4443
- CDR controller sometimes - failed firing event #4498
- The version is missing in the Login - About screen #4259
- admin UI - error message when it should not be displayed #4369
- Wrong error messages displayed when trying to change a domain name
with an incorrect one #4400
- The activation key is not removed after the activation is done #3232
- Admin UI - save should auto-remove spaces when exists #3331