### PR TITLE
Dev 428

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -10,6 +10,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - User Action Required should have (!)
 
 ## [Unreleased]
+## [Dev:Build_428] - 2018-11-04
+- Can print url pdf file when printing is disabled #4379
+- Reset Certificate uploaded and revert to Ericom Certificate #4315
+- Another LDAP login issue (reported by KKA) #4156
+- Once Ldap login is configured, it should sign out the current users from all sessions of the admin #4100
+- Underline of unconverted character string (#146) #3975
+- Japanese character conversion candidate display position #3961
+- When node is not in swarm or no leader, status-node returns a script error #3276
+- Backspace after using left arrow in Japanese is not working as expected #2192
+- portal mode - ignores license and session limit tabs #4601
+- if during addnode running fatal error is thrown addnode script is not stopped. #3864
+- Remote File Preview #879
+- Proxyless mode enable/disable #4597
+
+
 ## [Dev:Build_427] - 2018-10-31
 - string update #4564
 - (*) Spellcheck not working on Salesforce iframes #4351

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - if during addnode running fatal error is thrown addnode script is not stopped. #3864
 - Remote File Preview #879
 - Proxyless mode enable/disable #4597
+- Change order of values #4613
 
 
 ## [Dev:Build_427] - 2018-10-31

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -3,7 +3,7 @@ SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_428
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:181104-06.51-3140
+shield-admin:latest shield-admin:181104-11.25-3142
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181023-13.17-3038
 icap-server:latest icap-server:181104-05.39-3139

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,19 +1,19 @@
-#Build Dev:Build_427 on 18/10/31 
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_427
+#Build Dev:Build_428 on 18/11/04 
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_428
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:181029-16.08-3089
+shield-admin:latest shield-admin:181104-06.51-3140
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181023-13.17-3038
-icap-server:latest icap-server:181029-14.14-3087
-shield-cef:latest shield-cef:181031-10.18-3096
-broker-server:latest broker-server:181023-14.35-3041
+icap-server:latest icap-server:181104-05.39-3139
+shield-cef:latest shield-cef:181104-06.51-3140
+broker-server:latest broker-server:181104-05.39-3139
 shield-collector:latest shield-collector:181021-13.12-3023
-shield-elk:latest shield-elk:181029-09.44-3075
+shield-elk:latest shield-elk:181101-15.27-3129
 extproxy:latest extproxy:181010-18.49-2935
-shield-cdr-dispatcher:latest shield-cdr-dispatcher:181010-18.49-2935
-shield-cdr-controller:latest shield-cdr-controller:181023-10.29-3030
+shield-cdr-dispatcher:latest shield-cdr-dispatcher:181101-15.18-3127
+shield-cdr-controller:latest shield-cdr-controller:181031-11.34-3098
 shield-web-service:latest shield-web-service:181015-10.29-2966
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
 shield-authproxy:latest shield-authproxy:181023-20.04-3045
@@ -21,9 +21,9 @@ node-installer:latest node-installer:180503-17.04
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
-shield-autoupdate:latest shield-autoupdate:181029-09.54-3076
+shield-autoupdate:latest shield-autoupdate:181102-09.14-3134
 shield-notifier:latest shield-notifier:181021-12.38-3020
 shield-dns:latest shield-dns:181029-09.26-3074
 shield-proxyless-connector:latest shield-proxyless-connector:181025-17.07-3061
-es-file-preview:latest es-file-preview:181031-07.32-3094
+es-file-preview:latest es-file-preview:181102-09.24-3135
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_428] - 2018-11-04
- Can print url pdf file when printing is disabled #4379
- Reset Certificate uploaded and revert to Ericom Certificate #4315
- Another LDAP login issue (reported by KKA) #4156
- Once Ldap login is configured, it should sign out the current users
from all sessions of the admin #4100
- Underline of unconverted character string (#146) #3975
- Japanese character conversion candidate display position #3961
- When node is not in swarm or no leader, status-node returns a script
error #3276
- Backspace after using left arrow in Japanese is not working as
expected #2192
- portal mode - ignores license and session limit tabs #4601
- if during addnode running fatal error is thrown addnode script is not
stopped. #3864
- Remote File Preview #879
- Proxyless mode enable/disable #4597