### PR TITLE
Dev 447

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_447] - 2018-12-06
+
+- Japanese - problems with the keyboard #4847
+- Implementing Named Users Licensing #4783
+- Update for CentOS support 
+- es-system monitor doesn't function on centos #4908 
+
 ## [Dev:Build_446] - 2018-12-05
 
 - Admin set Image Quality and FPS - feedback #4862

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,13 +1,13 @@
-#Build Dev:Build_446 on 18/12/05
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_446
+#Build Dev:Build_447 on 18/12/06
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_447
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:181205-10.56-3366
+shield-admin:latest shield-admin:181206-16.13-3367
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181118-17.20-3222
-icap-server:latest icap-server:181205-08.175-3364
-shield-cef:latest shield-cef:181205-08.175-3364
+icap-server:latest icap-server:181206-16.54-3368
+shield-cef:latest shield-cef:181206-16.54-3368
 shield-collector:latest shield-collector:181118-15.49-3220
 shield-elk:latest shield-elk:181119-07.23-3224
 extproxy:latest extproxy:181118-17.20-3222


### PR DESCRIPTION
## [Dev:Build_447] - 2018-12-06

- Japanese - problems with the keyboard #4847
- Implementing Named Users Licensing #4783
- Update for CentOS support
- es-system monitor doesn't function on centos #4908