### PR TITLE
Dev 451

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_451] - 2018-12-11
+
+- Japanese - Suggestion doubled #4906
+- Japanese - First letter is doubled in Internet Explorer #4905
+- Japanese output issue #4747
+- Named user licensing - add a consul parameter #4928
+- Votiro AVR alert stay on after change the license to support antivirus #4929
+- alert about no matching license for Votiro, while sanitizing is working #4807
+- Not possible to change the right-click menu language to Japanese #4935
+- (*) First version of Categories in Shield #4275
+
 ## [Dev:Build_450] - 2018-12-11
 
 - Deployment Failed at Westbury Bank #4919

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,13 +1,13 @@
-#Build Dev:Build_450 on 18/12/11
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_450
+#Build Dev:Build_451 on 18/12/11
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_451
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:181210-12.29-3380
+shield-admin:latest shield-admin:181211-16.03-3406
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181118-17.20-3222
-icap-server:latest icap-server:181210-15.40-3382
-shield-cef:latest shield-cef:181210-15.40-3382
+icap-server:latest icap-server:181211-15.38-3405
+shield-cef:latest shield-cef:181211-15.38-3405
 shield-collector:latest shield-collector:181210-09.09-3375
 shield-elk:latest shield-elk:181119-07.23-3224
 extproxy:latest extproxy:181118-17.20-3222
@@ -15,18 +15,18 @@ shield-cdr-dispatcher:latest shield-cdr-dispatcher:181119-07.23-3224
 shield-cdr-controller:latest shield-cdr-controller:181130-09.49-3320
 shield-web-service:latest shield-web-service:181118-15.49-3220
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
-shield-authproxy:latest shield-authproxy:181205-08.175-3364
+shield-authproxy:latest shield-authproxy:181211-12.39-3394
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
-shield-autoupdate:latest shield-autoupdate:181211-08.00-3384
+shield-autoupdate:latest shield-autoupdate:181211-16.17-3408
 shield-notifier:latest shield-notifier:181128-15.52-3308
 shield-dns:latest shield-dns:181029-09.26-3074
 shield-proxyless-connector:latest shield-proxyless-connector:181204-13.14-3358
 es-file-preview:latest es-file-preview:181125-07.31-3259
 es-system-configuration:latest es-system-configuration:181127-10.19-3295
-es-system-monitor:latest es-system-monitor:181203-14.27-3338
+es-system-monitor:latest es-system-monitor:181211-14.52-3401
 es-license-manager:latest es-license-manager:181211-08.31-3385
 es-remote-browser-scaler:latest es-remote-browser-scaler:181126-13.29-3287
-es-policy-manager:latest es-policy-manager:181205-08.175-3364
+es-policy-manager:latest es-policy-manager:181211-12.39-3394
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_451] - 2018-12-11

- Japanese - Suggestion doubled #4906
- Japanese - First letter is doubled in Internet Explorer #4905
- Japanese output issue #4747
- Named user licensing - add a consul parameter #4928
- Votiro AVR alert stay on after change the license to support antivirus #4929
- alert about no matching license for Votiro, while sanitizing is working #4807
- Not possible to change the right-click menu language to Japanese #4935
- (*) First version of Categories in Shield #4275