### PR TITLE
Dev 455

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_455] - 2018-12-16
+
+- Encode the URL that remote browser sends to the policy manager in order to support other languages and url parameters
+Correctly set the group ID of the category when domain/URL was blocked due to “unsecured site” (securityGroupID)
+- Added category 35 (Private IP Addresses)
+- Fixed block message when domain is blocked by icap
+- When the remote browser blocks a URL, added the group ID (“catid”) to the URL, so we can track if blocking was done on the correct category (not available when domain is blocked by icap)
+- Added the full policy to the remote browser debug (performance & statss) panel (CTRL + SHIFT + ~), so we can track if the correct policy was assigned by the policy manager
+
 ## [Dev:Build_454] - 2018-12-13
 
 - Exclude IPs for RateLimit #4961

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,13 +1,13 @@
-#Build Dev:Build_454 on 18/12/16
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_454
+#Build Dev:Build_455 on 18/12/16
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_455
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
 shield-admin:latest shield-admin:181214-14.24-3431
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181118-17.20-3222
-icap-server:latest icap-server:181214-14.24-3431
-shield-cef:latest shield-cef:181213-13.43-3426
+icap-server:latest icap-server:181216-14.42-3440
+shield-cef:latest shield-cef:181216-15.05-3442
 shield-collector:latest shield-collector:181210-09.09-3375
 shield-elk:latest shield-elk:181119-07.23-3224
 extproxy:latest extproxy:181118-17.20-3222
@@ -15,7 +15,7 @@ shield-cdr-dispatcher:latest shield-cdr-dispatcher:181119-07.23-3224
 shield-cdr-controller:latest shield-cdr-controller:181130-09.49-3320
 shield-web-service:latest shield-web-service:181118-15.49-3220
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
-shield-authproxy:latest shield-authproxy:181212-14.29-3415
+shield-authproxy:latest shield-authproxy:181216-15.18-3443
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
@@ -25,8 +25,8 @@ shield-dns:latest shield-dns:181029-09.26-3074
 shield-proxyless-connector:latest shield-proxyless-connector:181204-13.14-3358
 es-file-preview:latest es-file-preview:181125-07.31-3259
 es-system-configuration:latest es-system-configuration:181212-16.32-3420
-es-system-monitor:latest es-system-monitor:181211-14.52-3401
+es-system-monitor:latest es-system-monitor:181216-14.31-3438
 es-license-manager:latest es-license-manager:181211-08.31-3385
 es-remote-browser-scaler:latest es-remote-browser-scaler:181126-13.29-3287
-es-policy-manager:latest es-policy-manager:181213-15.24-3428
+es-policy-manager:latest es-policy-manager:181216-14.53-3441
 # This needs to be the last line

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -3,7 +3,7 @@ SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_455
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:181214-14.24-3431
+shield-admin:latest shield-admin:181216-15.40-3445
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181118-17.20-3222
 icap-server:latest icap-server:181216-14.42-3440


### PR DESCRIPTION
## [Dev:Build_455] - 2018-12-16

- Encode the URL that remote browser sends to the policy manager in order to support other languages and url parameters
Correctly set the group ID of the category when domain/URL was blocked due to “unsecured site” (securityGroupID)
- Added category 35 (Private IP Addresses)
- Fixed block message when domain is blocked by icap
- When the remote browser blocks a URL, added the group ID (“catid”) to the URL, so we can track if blocking was done on the correct category (not available when domain is blocked by icap)
- Added the full policy to the remote browser debug (performance & statss) panel (CTRL + SHIFT + ~), so we can track if the correct policy was assigned by the policy manager