### PR TITLE
Dev 466

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_466] - 2019-01-14
+
+- Fix phishing report in case the site detected by both runtime and category #5198
+- Multi node - when one node is shut down ./status.sh -n doesn't work #5102
+- KKA - [[Urgent]][[Investigate]] QA#705718 Failure occurs when returning from NIC down/up. #219 #5098
+- Copy certificate instructions from ericom.com to ICAP #4924
+- Blank tab opened after the pop up is displayed #5226
+- Selective Isolation #5194
+
 ## [Dev:Build_465.1] - 2019-01-09
 
 - Review and clean categories errors in shield jer #5153

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,13 +1,13 @@
-#Build Dev:Build_465.1 on 19/01/09
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_465.1
+#Build Dev:Build_466 on 19/01/14
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_466
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:190109-12.39-3568
+shield-admin:latest shield-admin:190114-15.59-3597
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181118-17.20-3222
-icap-server:latest icap-server:190110-13.56-3581
-shield-cef:latest shield-cef:190109-15.45-3573
+icap-server:latest icap-server:190114-15.59-3597
+shield-cef:latest shield-cef:190114-15.59-3597
 shield-collector:latest shield-collector:181210-09.09-3375
 shield-elk:latest shield-elk:181230-17.53-3534
 extproxy:latest extproxy:181230-11.52-3532
@@ -15,19 +15,19 @@ shield-cdr-dispatcher:latest shield-cdr-dispatcher:190103-13.10-3538
 shield-cdr-controller:latest shield-cdr-controller:181230-11.52-3532
 shield-web-service:latest shield-web-service:181118-15.49-3220
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
-shield-authproxy:latest shield-authproxy:190110-09.57-3578
+shield-authproxy:latest shield-authproxy:190114-15.59-3597
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
-shield-autoupdate:latest shield-autoupdate:190110-10.07-3579
+shield-autoupdate:latest shield-autoupdate:190114-12.48-3592
 shield-notifier:latest shield-notifier:181231-12.56-3535
 shield-dns:latest shield-dns:181029-09.26-3074
-shield-proxyless-connector:latest shield-proxyless-connector:190109-15.45-3573
+shield-proxyless-connector:latest shield-proxyless-connector:190110-15.22-3582
 es-file-preview:latest es-file-preview:190103-13.10-3538
 es-system-configuration:latest es-system-configuration:181231-17.14-3537
 es-system-monitor:latest es-system-monitor:181216-14.31-3438
 es-license-manager:latest es-license-manager:181230-11.52-3532
 es-remote-browser-scaler:latest es-remote-browser-scaler:181126-13.29-3287
-es-policy-manager:latest es-policy-manager:190110-09.57-3578
+es-policy-manager:latest es-policy-manager:190114-15.59-3597
 es-core-sync:latest es-core-sync:190110-15.22-3582
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_466] - 2019-01-14

- Fix phishing report in case the site detected by both runtime and category #5198
- Multi node - when one node is shut down ./status.sh -n doesn't work #5102
- KKA - [[Urgent]][[Investigate]] QA#705718 Failure occurs when returning from NIC down/up. #219 #5098
- Copy certificate instructions from ericom.com to ICAP #4924
- Blank tab opened after the pop up is displayed #5226
- Selective Isolation #5194