### PR TITLE
Dev 469

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_469] - 2019-01-17
+
+- Liveness & readyness probs for cdr-controller, cdr-dispatcher, preview #5277
+- Pre-installation checks - ubuntu 18.04 update #5231
+- AdminUI: Category above Policy - fix the tool tip #4959
+- Admin doesn't generate new certificate when FQDN changes #5282
+- Category - search is not working #5268
+- Category - suspected need to be one of the first #5267
+- License counting for white session #5227
+- Tech preview features are not displayed at the admin UI when disable/enable some of them #5171
+
+ 
 ## [Dev:Build_468] - 2019-01-16
 
 - AWS alert - reduce memory requirements to be 7/15 #5259

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,18 +1,18 @@
-#Build Dev:Build_468 on 19/01/16
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_468
+#Build Dev:Build_469 on 19/01/17
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_469
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:181022-20.45-3029
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
-shield-admin:latest shield-admin:190116-10.54-3624
+shield-admin:latest shield-admin:190116-17.10-3634
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:181118-17.20-3222
-icap-server:latest icap-server:190116-09.16-3620
+icap-server:latest icap-server:190116-17.10-3634
 shield-cef:latest shield-cef:190115-15.36-3612
-shield-collector:latest shield-collector:190115-16.18-3614
+shield-collector:latest shield-collector:190116-14.07-3629
 shield-elk:latest shield-elk:181230-17.53-3534
-extproxy:latest extproxy:190115-10.09-3600
-shield-cdr-dispatcher:latest shield-cdr-dispatcher:190103-13.10-3538
-shield-cdr-controller:latest shield-cdr-controller:181230-11.52-3532
+extproxy:latest extproxy:190116-22.09-3635
+shield-cdr-dispatcher:latest shield-cdr-dispatcher:190116-13.35-3628
+shield-cdr-controller:latest shield-cdr-controller:190116-13.35-3628
 shield-web-service:latest shield-web-service:181118-15.49-3220
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
 shield-authproxy:latest shield-authproxy:190114-15.59-3597
@@ -23,7 +23,7 @@ shield-autoupdate:latest shield-autoupdate:190114-12.48-3592
 shield-notifier:latest shield-notifier:181231-12.56-3535
 shield-dns:latest shield-dns:181029-09.26-3074
 shield-proxyless-connector:latest shield-proxyless-connector:190110-15.22-3582
-es-file-preview:latest es-file-preview:190103-13.10-3538
+es-file-preview:latest es-file-preview:190116-13.35-3628
 es-system-configuration:latest es-system-configuration:181231-17.14-3537
 es-system-monitor:latest es-system-monitor:190116-11.08-3625
 es-license-manager:latest es-license-manager:181230-11.52-3532


### PR DESCRIPTION
## [Dev:Build_469] - 2019-01-17

- Liveness & readyness probs for cdr-controller, cdr-dispatcher, preview #5277
- Pre-installation checks - ubuntu 18.04 update #5231
- AdminUI: Category above Policy - fix the tool tip #4959
- Admin doesn't generate new certificate when FQDN changes #5282
- Category - search is not working #5268
- Category - suspected need to be one of the first #5267
- License counting for white session #5227
- Tech preview features are not displayed at the admin UI when disable/enable some of them #5171