### PR TITLE
Dev501

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,22 +11,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_501] - 2019-03-26
+
+- [[Bug]] QA#727182 ELK container time zone remains in UTC #5778
+- Ensure Electron exits on idle timeout ( Shield-Feedback#281 ) #5768
+
 ## [Dev:Build_500] - 2019-03-26
 
 - Cloud: Show Browser Farm Version #5686
 - Translation in Admin is not ok if Language is not English (en-us) #5770
-- Ensure Electron exits on idle timeout ( Shield-Feedback#281 ) #5768
 - Show Votiro Version in the Admin (+recommended) #5462
 - Default rule to block aws metadata site - 169.254.169.254 
 - Allow setting the locale in Electron/Chromium #5597
 - Fixed Burst issues 
 - Updated translation files #5722
 - Organize Cloud&K8s settings in the admin #5574
-- Fix NSS; Fix timezone settings #5788
 - Bypass Sending Alert Mail and Upstream Proxy #5780
-- [[Bug]] QA#727182 ELK container time zone remains in UTC #5778
 - Resources - Burst time definition #5499
-
 
 ## [Dev:Build_499] - 2019-03-20
 

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,11 +11,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [Dev:Build_500] - 2019-03-24
+## [Dev:Build_500] - 2019-03-26
 
 - Cloud: Show Browser Farm Version #5686
-- Show Votiro Version in the Admin (+recommended) #5462
 - Translation in Admin is not ok if Language is not English (en-us) #5770
+- Ensure Electron exits on idle timeout ( Shield-Feedback#281 ) #5768
+- Show Votiro Version in the Admin (+recommended) #5462
+- Default rule to block aws metadata site - 169.254.169.254 
+- Allow setting the locale in Electron/Chromium #5597
+- Fixed Burst issues 
+- Updated translation files #5722
+- Organize Cloud&K8s settings in the admin #5574
+- Fix NSS; Fix timezone settings #5788
+- Bypass Sending Alert Mail and Upstream Proxy #5780
+- [[Bug]] QA#727182 ELK container time zone remains in UTC #5778
+- Resources - Burst time definition #5499
+
 
 ## [Dev:Build_499] - 2019-03-20
 

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_500] - 2019-03-24
+
+- Cloud: Show Browser Farm Version #5686
+- Show Votiro Version in the Admin (+recommended) #5462
+- Translation in Admin is not ok if Language is not English (en-us) #5770
 
 ## [Dev:Build_499] - 2019-03-20
 

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,5 +1,5 @@
-#Build Dev:Build_500 on 19/03/26
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_500
+#Build Dev:Build_501 on 19/03/26
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_501
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,4 +1,4 @@
-#Build Dev:Build_500 on 19/03/24
+#Build Dev:Build_500 on 19/03/26
 SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_500
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:190314-08.02-3983
@@ -6,7 +6,7 @@ shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:190320-13.27-4022
 shield-collector:latest shield-collector:190307-18.35-3950
-shield-elk:latest shield-elk:190312-14.21-3974
+shield-elk:latest shield-elk:190325-13.42-4039
 shield-web-service:latest shield-web-service:190310-12.20-3962
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
 shield-authproxy:latest shield-authproxy:190320-13.27-4022
@@ -15,14 +15,14 @@ netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
 shield-autoupdate:latest shield-autoupdate:190320-09.34-4011
 es-system-monitor:latest es-system-monitor:190310-12.20-3962
-es-core-sync:latest es-core-sync:190319-09.33-4005
-shield-admin:latest shield-admin:190322-10.12-4027
-icap-server:latest icap-server:190318-20.39-4002
-shield-cef:latest shield-cef:190320-12.21-4017
+es-core-sync:latest es-core-sync:190324-14.33-4030
+shield-admin:latest shield-admin:190326-12.31-4050
+icap-server:latest icap-server:190325-12.32-4035
+shield-cef:latest shield-cef:190325-09.37-4032]
 extproxy:latest extproxy:190310-12.20-3962
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190318-20.39-4002
-shield-cdr-controller:latest shield-cdr-controller:190321-09.16-4025
-shield-notifier:latest shield-notifier:190310-12.20-3962
+shield-cdr-controller:latest shield-cdr-controller:190326-12.45-4051
+shield-notifier:latest shield-notifier:190325-13.42-4039
 shield-proxyless-connector:latest shield-proxyless-connector:190307-13.41-3939
 es-file-preview:latest es-file-preview:190206-11.37-3767
 es-system-configuration:latest es-system-configuration:190319-11.13-4007
@@ -30,4 +30,6 @@ es-license-manager:latest es-license-manager:190310-12.20-3962
 es-remote-browser-scaler:latest es-remote-browser-scaler:190310-12.20-3962
 es-policy-manager:latest es-policy-manager:190320-09.34-4011
 shield-dns:latest shield-dns:190312-14.21-3974
+es-farm-scaler:latest es-farm-scaler:190324-10.27-4029
+es-farm-sync:latest es-farm-sync:190324-14.33-4030
 # This needs to be the last line

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,5 +1,5 @@
-#Build Dev:Build_499 on 19/03/20
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_499
+#Build Dev:Build_500 on 19/03/24
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_500
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
@@ -16,12 +16,12 @@ speedtest:latest speedtest:181010-18.49-2935
 shield-autoupdate:latest shield-autoupdate:190320-09.34-4011
 es-system-monitor:latest es-system-monitor:190310-12.20-3962
 es-core-sync:latest es-core-sync:190319-09.33-4005
-shield-admin:latest shield-admin:190320-13.01-4019
+shield-admin:latest shield-admin:190322-10.12-4027
 icap-server:latest icap-server:190318-20.39-4002
 shield-cef:latest shield-cef:190320-12.21-4017
 extproxy:latest extproxy:190310-12.20-3962
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190318-20.39-4002
-shield-cdr-controller:latest shield-cdr-controller:190320-13.16-4021
+shield-cdr-controller:latest shield-cdr-controller:190321-09.16-4025
 shield-notifier:latest shield-notifier:190310-12.20-3962
 shield-proxyless-connector:latest shield-proxyless-connector:190307-13.41-3939
 es-file-preview:latest es-file-preview:190206-11.37-3767


### PR DESCRIPTION
## [Dev:Build_501] - 2019-03-26

- Cloud: Show Browser Farm Version #5686
- Translation in Admin is not ok if Language is not English (en-us) #5770
- Ensure Electron exits on idle timeout ( Shield-Feedback#281 ) #5768
- Show Votiro Version in the Admin (+recommended) #5462
- Default rule to block aws metadata site - 169.254.169.254 
- Allow setting the locale in Electron/Chromium #5597
- Fixed Burst issues 
- Updated translation files #5722
- Organize Cloud&K8s settings in the admin #5574
- Fix NSS; Fix timezone settings #5788
- Bypass Sending Alert Mail and Upstream Proxy #5780
- [[Bug]] QA#727182 ELK container time zone remains in UTC #5778
- Resources - Burst time definition #5499