### PR TITLE
Dev 503

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Adblock list is not synced to farm #5826
 - don't use ext-proxy in farm mode when adblock is off
 - can't install shield on centos and redhat #5886
-
+- Authentication popup - maintain in focus w/o messages in the background #5857
 
 ## [Dev:Build_502] - 2019-03-28
 

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [Dev:Build_503] - 2019-04-10
+## [Dev:Build_503.1] - 2019-04-10
 
 - Safari background tab websocket force disconnect #5867
 - Farm - build 502 - browsers are being terminated #5862

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_503] - 2019-04-10
+
+- Safari background tab websocket force disconnect #5867
+- Farm - build 502 - browsers are being terminated #5862
+- Printing is not working #5811
+- Redirects with utf8 location don't work properly #5752
+- Severe issue at KKA's customer required reboot #5623
+- Form is not opened as expected (KKA) #5885
+- [[trouble]] QA#729084(yuchida)Shield site is blank (KKA) #5890
+- Cloud - support idle load timeout in farm #5681
+- Prepare OVA with Shield installed and all images pulled #5629
+- Prepare OVA for Shield Registry (Images and shield files) #5630
+- Resources with accepted invalid certificate don't load #5853
+- Unknown alert ID 27 #5850
+- burst event - when leaving timeout without value, the browsers are being removed #5845
+- URL is incorrect when opening a PDF file #5792
+- problem to load pages- network is slow #5562
+- Unable to display specific page (white screen) - https://biz.kddi.com/ #5796
+- ICAP to pre-publish the default categories table only once #5475
+- Safari background tab websocket force disconnect #5867
+- Farm - build 502 - browsers are being terminated #5862
+- Resources - Burst time definition #5499
+- Increase the number of domain policies supported #5736
+- Votiro - support named policy #5190
+- Admin jquery update to 3.3.1
+- No need to check health of netstar if not used #5812
+- Phishing - not display notification / warning when categotires are disabled #5820
+- Adblock list is not synced to farm #5826
+- don't use ext-proxy in farm mode when adblock is off
+- can't install shield on centos and redhat #5886
+
+
 ## [Dev:Build_502] - 2019-03-28
 
 - Printing is not working #5811

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,5 +1,5 @@
-#Build Dev:Build_503 on 19/04/10
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_503
+#Build Dev:Build_503.1 on 19/04/10
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_503.1
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:190410-14.52-4081

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,35 +1,35 @@
-#Build Dev:Build_502.1 on 19/03/28
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_502.1
+#Build Dev:Build_503 on 19/04/10
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_503
 #docker-version 18.03.1
 shield-configuration:latest shield-configuration:190314-08.02-3983
-shield-consul-agent:latest shield-consul-agent:181018-11.29-3005
+shield-consul-agent:latest shield-consul-agent:190410-14.52-4081
 shield-portainer:latest shield-portainer:180930-11.41-2885
 proxy-server:latest proxy-server:190320-13.27-4022
 shield-collector:latest shield-collector:190307-18.35-3950
 shield-elk:latest shield-elk:190325-13.42-4039
 shield-web-service:latest shield-web-service:190310-12.20-3962
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
-shield-authproxy:latest shield-authproxy:190320-13.27-4022
+shield-authproxy:latest shield-authproxy:190410-16.06-4083
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
 shield-autoupdate:latest shield-autoupdate:190320-09.34-4011
 es-system-monitor:latest es-system-monitor:190310-12.20-3962
-es-core-sync:latest es-core-sync:190319-09.33-4005
-shield-admin:latest shield-admin:190326-12.31-4050
-icap-server:latest icap-server:190325-12.32-4035
-shield-cef:latest shield-cef:190327-15.26-4059
+es-core-sync:latest es-core-sync:190410-14.40-4080
+shield-admin:latest shield-admin:190410-16.26-4084
+icap-server:latest icap-server:190410-16.26-4084
+shield-cef:latest shield-cef:190410-16.40-4085
 extproxy:latest extproxy:190310-12.20-3962
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190328-14.03-4063
 shield-cdr-controller:latest shield-cdr-controller:190326-12.45-4051
 shield-notifier:latest shield-notifier:190325-13.42-4039
 shield-proxyless-connector:latest shield-proxyless-connector:190307-13.41-3939
 es-file-preview:latest es-file-preview:190206-11.37-3767
-es-system-configuration:latest es-system-configuration:190319-11.13-4007
+es-system-configuration:latest es-system-configuration:190410-16.06-4083
 es-license-manager:latest es-license-manager:190310-12.20-3962
 es-remote-browser-scaler:latest es-remote-browser-scaler:190310-12.20-3962
-es-policy-manager:latest es-policy-manager:190320-09.34-4011
+es-policy-manager:latest es-policy-manager:190410-16.06-4083
 shield-dns:latest shield-dns:190312-14.21-3974
-es-farm-scaler:latest es-farm-scaler:190324-10.27-4029
+es-farm-scaler:latest es-farm-scaler:190410-14.40-4080
 es-farm-sync:latest es-farm-sync:190324-14.33-4030
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_503] - 2019-04-10

- Safari background tab websocket force disconnect #5867
- Farm - build 502 - browsers are being terminated #5862
- Printing is not working #5811
- Redirects with utf8 location don't work properly #5752
- Severe issue at KKA's customer required reboot #5623
- Form is not opened as expected (KKA) #5885
- [[trouble]] QA#729084(yuchida)Shield site is blank (KKA) #5890
- Cloud - support idle load timeout in farm #5681
- Prepare OVA with Shield installed and all images pulled #5629
- Prepare OVA for Shield Registry (Images and shield files) #5630
- Resources with accepted invalid certificate don't load #5853
- Unknown alert ID 27 #5850
- burst event - when leaving timeout without value, the browsers are being removed #5845
- URL is incorrect when opening a PDF file #5792
- a problem to load pages- the network is slow #5562
- Unable to display specific page (white screen) - https://biz.kddi.com/ #5796
- ICAP to pre-publish the default categories table only once #5475
- Safari background tab websocket force disconnect #5867
- Farm - build 502 - browsers are being terminated #5862
- Resources - Burst time definition #5499
- Increase the number of domain policies supported #5736
- Votiro - support named policy #5190
- Admin jquery update to 3.3.1
- No need to check the health of netstar if not used #5812
- Phishing - not display notification / warning when categories are disabled #5820
- Adblock list is not synced to farm #5826
- don't use ext-proxy in farm mode when adblock is off
- can't install shield on centos and redhat #5886