### PR TITLE
Dev 512

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_512] - 2019-04-30
+
+- Burst Event can be set without enable it at the admin #5856
+- "Burst Events" and "Dynamic Nodes" are no longer "Tech Preview"
+- Do not show burst event table if empty
+- Make sure named policy 'Add' button is enabled after reopening
+- Show Sasa named policies
+
 ## [Dev:Build_511] - 2019-04-29
 
 - Reduce remote browser consul registration wait time #6007

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,5 +1,5 @@
-#Build Dev:Build_511 on 19/04/29
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_511
+#Build Dev:Build_512 on 19/04/30
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_512
 #docker-version 18.09.5 5:18.09.5~3-0~ubuntu-*
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:190418-11.14-4108
@@ -16,7 +16,7 @@ speedtest:latest speedtest:181010-18.49-2935
 shield-autoupdate:latest shield-autoupdate:190428-11.55-4125
 es-system-monitor:latest es-system-monitor:190429-07.15-4130
 es-core-sync:latest es-core-sync:190429-07.15-4130
-shield-admin:latest shield-admin:190429-15.01-4139
+shield-admin:latest shield-admin:190430-15.31-4145
 icap-server:latest icap-server:190429-13.24-4133
 shield-cef:latest shield-cef:190429-06.40-4129
 extproxy:latest extproxy:190417-12.40-4105
@@ -28,7 +28,7 @@ es-file-preview:latest es-file-preview:190429-07.15-4130
 es-system-configuration:latest es-system-configuration:190429-07.15-4130
 es-license-manager:latest es-license-manager:190429-07.15-4130
 es-remote-browser-scaler:latest es-remote-browser-scaler:190429-07.15-4130
-es-policy-manager:latest es-policy-manager:190429-13.24-4133
+es-policy-manager:latest es-policy-manager:190430-07.25-4141
 shield-dns:latest shield-dns:190312-14.21-3974
 es-farm-scaler:latest es-farm-scaler:190429-07.15-4130
 es-farm-sync:latest es-farm-sync:190429-07.15-4130


### PR DESCRIPTION
## [Dev:Build_512] - 2019-04-30

- Burst Event can be set without enable it at the admin #5856
- "Burst Events" and "Dynamic Nodes" are no longer "Tech Preview"
- Do not show burst event table if empty
- Make sure named policy 'Add' button is enabled after reopening
- Show Sasa named policies