### PR TITLE
Fix rpm for rel19.05

### DIFF
--- a/Setup/rpm/ericom_shield.spec.tpl
+++ b/Setup/rpm/ericom_shield.spec.tpl
@@ -23,7 +23,7 @@ Requires: redhat-release-server >= 7.5
 
 %else #"%{_buildfor_rel}" == "centos"
 
-Requires: docker-ce >= ${DOCKER_VERSION_LOW}, docker-ce < ${DOCKER_VERSION_HIGH}
+Requires: docker-ce >= 3:${DOCKER_VERSION_LOW}, docker-ce < 3:${DOCKER_VERSION_HIGH}
 Requires: centos-release >= 7-5
 
 %endif


### PR DESCRIPTION
Docker introduced epochs for Docker-CE on CentOS (just like on Ubuntu, but there they use epoch = 5 instead of 3 on CentOS).