### PR TITLE
Dev533

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -13,9 +13,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Dev:Build_533] - 2019-06-13
 
--
--
--
+- Data type conflict ruin reports #6479
+- Fix External Syslog for Kube #6427
+- Faster page load on search engines #6288
+- Installation of Dev_532 on clean machine is not working properly #6481
+- http failure notification at the dashboard #6447
+- After installing Dev_528 on 126.0.6.3, machine is not working properly #6433
+- support profiles based on X-Authenticated-Groups on https sites 
 
 ## [Dev:Build_532] - 2019-06-12
 

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_533] - 2019-06-13
+
+-
+-
+-
+
 ## [Dev:Build_532] - 2019-06-12
 
 - ReadOnly Phishing doesnt seem to work #6463

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,10 +1,10 @@
-#Build Dev:Build_532 on 19/06/12
-SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_532
+#Build Dev:Build_533 on 19/06/13
+SHIELD_VER=8.0.0.latest SHIELD_VER=Dev:Build_533
 #docker-version 18.09.5 5:18.09.5~3-0~ubuntu-*
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:190418-11.14-4108
 shield-portainer:latest shield-portainer:180930-11.41-2885
-proxy-server:latest proxy-server:190603-06.44-4297
+proxy-server:latest proxy-server:190613-09.27-4370
 shield-collector:latest shield-collector:190530-11.30-4283
 shield-elk:latest shield-elk:190325-13.42-4039
 shield-web-service:latest shield-web-service:190429-07.15-4130
@@ -16,8 +16,8 @@ speedtest:latest speedtest:181010-18.49-2935
 shield-autoupdate:latest shield-autoupdate:190602-14.22-4295
 es-system-monitor:latest es-system-monitor:190606-10.10-4320
 es-core-sync:latest es-core-sync:190612-09.54-4360
-shield-admin:latest shield-admin:190612-08.16-4357
-icap-server:latest icap-server:190611-14.08-4348
+shield-admin:latest shield-admin:190613-07.51-4367
+icap-server:latest icap-server:190613-11.57-4372
 shield-cef:latest shield-cef:190612-09.54-4360
 extproxy:latest extproxy:190529-11.34-4273
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190610-14.59-4339

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -18,7 +18,7 @@ es-system-monitor:latest es-system-monitor:190606-10.10-4320
 es-core-sync:latest es-core-sync:190612-09.54-4360
 shield-admin:latest shield-admin:190613-07.51-4367
 icap-server:latest icap-server:190613-11.57-4372
-shield-cef:latest shield-cef:190612-09.54-4360
+shield-cef:latest shield-cef:190613-13.54-4376
 extproxy:latest extproxy:190529-11.34-4273
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190610-14.59-4339
 shield-cdr-controller:latest shield-cdr-controller:190505-19.01-4158


### PR DESCRIPTION
## [Dev:Build_533] - 2019-06-13

- Data type conflict ruin reports #6479
- Fix External Syslog for Kube #6427
- Faster page load on search engines #6288
- Installation of Dev_532 on clean machine is not working properly #6481
- http failure notification at the dashboard #6447
- After installing Dev_528 on 126.0.6.3, machine is not working properly #6433
- support profiles based on X-Authenticated-Groups on https sites 