### PR TITLE
Dev 549

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Burst Events on Cloud are done on UTC instead of Admin Time #6260
 - Align all alerts to work in "Dynamic Nodes" mode #5930
 - OVA Preparation #6628
+- add live/ready port to ldap-proxy #6811
 
 ## [Dev:Build_548] - 2019-07-14
 

--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_549] - 2019-07-15
+
+- Remove memory pools from proxy server #6778
+- Fluent-bit service is not working in Dev_548 Kube #6772
+- Problem with urls goes white after ~10 seconds - autofill related issue #6753
+- Shield-perf consistent time format #6722
+- DNS Settings are empty #6642
+- Admin | Profiles table - validate after editing & missing tooltip #6525
+- Admin updated Japanese translations 
+- Instructions + Scripts for installing Shield on Centos #6781
+- Burst Events on Cloud are done on UTC instead of Admin Time #6260
+- Align all alerts to work in "Dynamic Nodes" mode #5930
+- OVA Preparation #6628
+
 ## [Dev:Build_548] - 2019-07-14
 
 - Admin - Named Policy - Add Named Policy dialog #6020

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -17,7 +17,7 @@ shield-autoupdate:latest shield-autoupdate:190701-13.13-4491
 es-system-monitor:latest es-system-monitor:190707-14.07-4532
 es-core-sync:latest es-core-sync:190714-05.44-4589
 shield-admin:latest shield-admin:190721-08.37-4616
-icap-server:latest icap-server:190716-13.58-4608
+icap-server:latest icap-server:190721-13.42-4619
 shield-cef:latest shield-cef:190718-10.27-4614
 extproxy:latest extproxy:190715-21.30-4606
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190714-07.21-4590
@@ -28,13 +28,13 @@ es-file-preview:latest es-file-preview:190715-05.43-4596
 es-system-configuration:latest es-system-configuration:190715-21.30-4606
 es-license-manager:latest es-license-manager:190707-14.07-4532
 es-remote-browser-scaler:latest es-remote-browser-scaler:190707-14.07-4532
-es-policy-manager:latest es-policy-manager:190721-08.37-4616
+es-policy-manager:latest es-policy-manager:190721-12.52-4617
 shield-dns:latest shield-dns:190523-19.10-4259
 es-farm-scaler:latest es-farm-scaler:190714-13.53-4594
 es-farm-sync:latest es-farm-sync:190721-08.37-4616
 es-api-gateway:latest es-api-gateway:190707-14.07-4532
 es-ldap-api:latest es-ldap-api:190707-14.07-4532
-es-ldap-proxy:latest es-ldap-proxy:190711-09.36-4572
+es-ldap-proxy:latest es-ldap-proxy:190721-13.55-4620
 es-proxy-egress:latest es-proxy-egress:190707-13.18-4529
 # es-consul-backup:latest es-shield-consul-backup:190711-09.36-4572
 # es-init-elasticsearch:latest es-init-elasticsearch:190709-07.24-4551

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,37 +1,37 @@
-#Build Dev:Build_548.1 on 19/07/14
-SHIELD_VER=8.0.0.latest SHIELD_VER=19.06:Build_548.1
+#Build Dev:Build_549 on 19/07/15
+SHIELD_VER=8.0.0.latest SHIELD_VER=19.06:Build_549
 #docker-version 18.09.5 5:18.09.5~3-0~ubuntu-*
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:190624-14.49-4452
 shield-portainer:latest shield-portainer:180930-11.41-2885
-proxy-server:latest proxy-server:190711-15.39-4583
-shield-collector:latest shield-collector:190714-05.32-4588
+proxy-server:latest proxy-server:190717-08.42-4609
+shield-collector:latest shield-collector:190717-11.11-4610
 shield-elk:latest shield-elk:190325-13.42-4039
 shield-web-service:latest shield-web-service:190707-14.07-4532
 shield-maintenance:latest shield-maintenance:181029-09.26-3074
-shield-authproxy:latest shield-authproxy:190715-21.30-4606
+shield-authproxy:latest shield-authproxy:190721-08.37-4616
 shield-logspout:latest shield-logspout:171123-17.23-642
 netdata:latest netdata:180114-08.17-1026
 speedtest:latest speedtest:181010-18.49-2935
 shield-autoupdate:latest shield-autoupdate:190701-13.13-4491
 es-system-monitor:latest es-system-monitor:190707-14.07-4532
 es-core-sync:latest es-core-sync:190714-05.44-4589
-shield-admin:latest shield-admin:190715-14.15-4604
-icap-server:latest icap-server:190715-09.11-4597
-shield-cef:latest shield-cef:190714-05.10-4587
+shield-admin:latest shield-admin:190721-08.37-4616
+icap-server:latest icap-server:190716-13.58-4608
+shield-cef:latest shield-cef:190718-10.27-4614
 extproxy:latest extproxy:190715-21.30-4606
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190714-07.21-4590
-shield-cdr-controller:latest shield-cdr-controller:190711-05.38-4566
+shield-cdr-controller:latest shield-cdr-controller:190721-08.37-4616
 shield-notifier:latest shield-notifier:190707-14.07-4532
 shield-proxyless-connector:latest shield-proxyless-connector:190708-07.41-4539
 es-file-preview:latest es-file-preview:190715-05.43-4596
 es-system-configuration:latest es-system-configuration:190715-21.30-4606
 es-license-manager:latest es-license-manager:190707-14.07-4532
 es-remote-browser-scaler:latest es-remote-browser-scaler:190707-14.07-4532
-es-policy-manager:latest es-policy-manager:190707-14.07-4532
+es-policy-manager:latest es-policy-manager:190721-08.37-4616
 shield-dns:latest shield-dns:190523-19.10-4259
 es-farm-scaler:latest es-farm-scaler:190714-13.53-4594
-es-farm-sync:latest es-farm-sync:190707-14.07-4532
+es-farm-sync:latest es-farm-sync:190721-08.37-4616
 es-api-gateway:latest es-api-gateway:190707-14.07-4532
 es-ldap-api:latest es-ldap-api:190707-14.07-4532
 es-ldap-proxy:latest es-ldap-proxy:190711-09.36-4572
@@ -39,4 +39,5 @@ es-proxy-egress:latest es-proxy-egress:190707-13.18-4529
 # es-consul-backup:latest es-shield-consul-backup:190711-09.36-4572
 # es-init-elasticsearch:latest es-init-elasticsearch:190709-07.24-4551
 # es-fluent-bit:latest es-fluent-bit:190711-09.36-4572
+# es-mng-system-monitor:latest es-mng-system-monitor:190721-08.37-4616
 # This needs to be the last line


### PR DESCRIPTION
## [Dev:Build_549] - 2019-07-15

- Remove memory pools from proxy server #6778
- Fluent-bit service is not working in Dev_548 Kube #6772
- Problem with urls goes white after ~10 seconds - autofill related issue #6753
- Shield-perf consistent time format #6722
- DNS Settings are empty #6642
- Admin | Profiles table - validate after editing & missing tooltip #6525
- Admin updated Japanese translations
- Instructions + Scripts for installing Shield on Centos #6781
- Burst Events on Cloud are done on UTC instead of Admin Time #6260
- Align all alerts to work in "Dynamic Nodes" mode #5930
- OVA Preparation #6628