### PR TITLE
Dev 574

### DIFF
--- a/Setup/Changelog.md
+++ b/Setup/Changelog.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [Dev:Build_573] - 2019-10-23
+
+- daily back up is missing #7341
+- backup / restore issue #7345
+- Shield - Video problems on MacOS SM#58 #7308
+- Align all alerts to work in "Dynamic Nodes" mode #5930
+- Users Reports #6981
+- Dashboard - browser gauge #7324
+- google docs - conversion candidate window #7005
+- Incorrect error message "URL's domain blocked by policy" when policy-manager not responding #5316
+- missing File Transfer > failure reports #7070
+- Admin - Settings - add a link to download Shield certificate #6497
+- Kube: Complete missing shield-stats fields (available in swarm) #6959
+- Blocked page on IE receives an error HTTP 403 instead of the Blocked Page #7281
+- authproxy has wrong proxyless ip in hosts.squid #7348
+- Shield - Video problems on MacOS SM#58 #7308
+
 ## [Dev:Build_572] - 2019-10-19
 
 - Duplicate application logs #7342

--- a/Setup/shield-version.txt
+++ b/Setup/shield-version.txt
@@ -1,5 +1,5 @@
-#Build Build_572 on 22/09/19
-SHIELD_VER=8.0.0.latest SHIELD_VER=19.09:Build_572
+#Build Build_573 on 23/09/19
+SHIELD_VER=8.0.0.latest SHIELD_VER=19.09:Build_573
 #docker-version 18.09.5 5:18.09.5~3-0~ubuntu-*
 shield-configuration:latest shield-configuration:190314-08.02-3983
 shield-consul-agent:latest shield-consul-agent:190624-14.49-4452
@@ -16,10 +16,10 @@ speedtest:latest speedtest:190811-11.10-4682
 shield-autoupdate:latest shield-autoupdate:190701-13.13-4491
 es-system-monitor:latest es-system-monitor:190903-13.00-121
 es-core-sync:latest es-core-sync:190811-12.31-4686
-shield-admin:latest shield-admin:190918-11.15-173
-icap-server:latest icap-server:190915-10.28-158
-shield-cef:latest shield-cef:190915-10.28-158
-extproxy:latest extproxy:190723-16.12-4643
+shield-admin:latest shield-admin:190923-17.49-190
+icap-server:latest icap-server:190923-16.50-189
+shield-cef:latest shield-cef:190923-16.50-189
+extproxy:latest extproxy:190923-08.22-179
 shield-cdr-dispatcher:latest shield-cdr-dispatcher:190714-07.21-4590
 shield-cdr-controller:latest shield-cdr-controller:190909-06.20-141
 shield-notifier:latest shield-notifier:190707-14.07-4532
@@ -31,7 +31,7 @@ es-remote-browser-scaler:latest es-remote-browser-scaler:190811-12.31-4686
 es-policy-manager:latest es-policy-manager:190905-10.53-130
 shield-dns:latest shield-dns:190523-19.10-4259
 es-farm-scaler:latest es-farm-scaler:190912-15.17-150
-es-farm-sync:latest es-farm-sync:190916-10.09-162
+es-farm-sync:latest es-farm-sync:190923-17.49-190
 es-api-gateway:latest es-api-gateway:190707-14.07-4532
 es-ldap-api:latest es-ldap-api:190811-12.31-4686
 es-ldap-proxy:latest es-ldap-proxy:190912-15.17-150
@@ -39,11 +39,11 @@ es-proxy-egress:latest es-proxy-egress:190707-13.18-4529
 # esBrowserScheduler: securebrowsing/k8s-browser-scheduler:190110-12.24
 # esNodeGroupsScaler: atlassian/escalator:v1.6.2
 # esKibana: docker.elastic.co/kibana/kibana-oss:7.1.1
-# es-consul-backup:latest es-shield-consul-backup:190801-11.56-4664
+# es-consul-backup:latest es-shield-consul-backup:190923-17.49-190
 # es-init-elasticsearch:latest es-init-elasticsearch:190922-10.52-178
-# es-fluent-bit:latest es-fluent-bit:190915-13.30-159
-# es-mng-system-monitor:latest es-mng-system-monitor:190916-10.09-162
-# esConsulBackup: securebrowsing/es-shield-consul-backup:190918-09.08-171
+# es-fluent-bit:latest es-fluent-bit:190923-13.59-183
+# es-mng-system-monitor:latest es-mng-system-monitor:190923-17.49-190
+# esConsulBackup: securebrowsing/es-shield-consul-backup:190923-17.49-190
 # shield-virtual-client:latest shield-virtual-client:190909-05.59-140
 # esExternalDNS: registry.opensource.zalan.do/teapot/external-dns:v0.5.12
 # esInitElasticsearch: securebrowsing/es-init-elasticsearch:190911-13.07-148


### PR DESCRIPTION
## [Dev:Build_573] - 2019-10-23

- daily back up is missing #7341
- backup / restore issue #7345
- Shield - Video problems on MacOS SM#58 #7308
- Align all alerts to work in "Dynamic Nodes" mode #5930
- Users Reports #6981
- Dashboard - browser gauge #7324
- google docs - conversion candidate window #7005
- Incorrect error message "URL's domain blocked by policy" when policy-manager not responding #5316
- missing File Transfer > failure reports #7070
- Admin - Settings - add a link to download Shield certificate #6497
- Kube: Complete missing shield-stats fields (available in swarm) #6959
- Blocked page on IE receives an error HTTP 403 instead of the Blocked Page #7281
- authproxy has wrong proxyless ip in hosts.squid #7348
- Shield - Video problems on MacOS SM#58 #7308