### PR TITLE
SHIELD-6308 Fix install-shield-from-container.sh

### DIFF
--- a/Kube/scripts/install-shield-from-container.sh
+++ b/Kube/scripts/install-shield-from-container.sh
@@ -242,7 +242,7 @@ EOF
     systemctl reload docker
 fi
 
-if [ $ES_OFFLINE = "false" ] && [ ! -z "${ES_OFFLINE_REGISTRY_PREFIX}" ]; then
+if [ $ES_OFFLINE = "false" ] || [ ! -z "${ES_OFFLINE_REGISTRY_PREFIX}" ]; then
    docker image pull "${ES_OFFLINE_REGISTRY_PREFIX}securebrowsing/es-shield-cli:$VERSION"
 fi   
 if [ $(docker image ls | grep -c $VERSION) -lt 1 ]; then

--- a/Kube/scripts/install-shield-from-container.sh
+++ b/Kube/scripts/install-shield-from-container.sh
@@ -242,7 +242,7 @@ EOF
     systemctl reload docker
 fi
 
-if [ $ES_OFFLINE = "false" ]; then
+if [ $ES_OFFLINE = "false" ] && [ ! -z "${ES_OFFLINE_REGISTRY_PREFIX}" ]; then
    docker image pull "${ES_OFFLINE_REGISTRY_PREFIX}securebrowsing/es-shield-cli:$VERSION"
 fi   
 if [ $(docker image ls | grep -c $VERSION) -lt 1 ]; then


### PR DESCRIPTION
Fix

```
+ bash ./install-shield-from-container.sh -v Rel-20.05.649 -l --registry 126.0.55.38:5000
******** ./install-shield-from-container.sh -v Rel-20.05.649 -l --registry 126.0.55.38:5000
Version: Rel-20.05.649

Error: Cannot Pull Docker image es-shield-cli: Rel-20.05.649
Verify the version exists and the password is correct
+ '[' 1 '!=' 0 ']'
+ echo

+ echo '*************** Installation Failed, Exiting!'
*************** Installation Failed, Exiting!
+ echo

+ echo 'Make sure you are using the right password!'
Make sure you are using the right password!
+ exit 1
```

when running in an offline environment with a registry.